### PR TITLE
Add user collections and theme toggle

### DIFF
--- a/adapters/cloudflare-worker/migrations/0002_user_collections.sql
+++ b/adapters/cloudflare-worker/migrations/0002_user_collections.sql
@@ -1,0 +1,3 @@
+alter table collections add column owner_id text references users(id) on delete cascade;
+
+create index if not exists collections_owner_idx on collections(owner_id, created_at desc);

--- a/adapters/cloudflare-worker/src/api/collections.ts
+++ b/adapters/cloudflare-worker/src/api/collections.ts
@@ -41,9 +41,10 @@ export async function handleCreators(ctx: AppContext, parts: string[]) {
   if (ctx.request.method === "GET" && parts.length === 1 && parts[0] === "leaderboard") {
     const viewer = await currentUser(ctx);
     const pets = (await listPets(ctx, "", undefined, [], viewer, "new", undefined, parseContentMode(ctx.url.searchParams.get("content")))).pets;
+    const shadowbannedCreators = await shadowbannedUserIds(ctx);
     const byCreator = new Map<string, { id: string; handle: string | null; displayName: string; petCount: number; viewCount: number; likeCount: number; topPets: typeof pets }>();
     for (const pet of pets) {
-      if (!pet.ownerId) continue;
+      if (!pet.ownerId || shadowbannedCreators.has(pet.ownerId)) continue;
       const item = byCreator.get(pet.ownerId) || { id: pet.ownerId, handle: pet.ownerHandle, displayName: pet.ownerName, petCount: 0, viewCount: 0, likeCount: 0, topPets: [] };
       item.petCount += 1; item.viewCount += pet.viewCount; item.likeCount += pet.likeCount; item.topPets.push(pet);
       byCreator.set(pet.ownerId, item);
@@ -227,6 +228,11 @@ async function userTarget(ctx: AppContext, value: string) {
       ? ctx.env.DB.prepare("select id, email from users where email = ?").bind(value)
       : ctx.env.DB.prepare("select id, email from users where id = ?").bind(value)
   );
+}
+
+async function shadowbannedUserIds(ctx: AppContext) {
+  const rows = await all<{ id: string }>(ctx.env.DB.prepare("select id from users where shadowbanned_at is not null"));
+  return new Set(rows.map((row) => row.id));
 }
 
 async function setProfileShadowban(ctx: AppContext, userId: string, shadowbanned: boolean) {

--- a/adapters/cloudflare-worker/src/api/collections.ts
+++ b/adapters/cloudflare-worker/src/api/collections.ts
@@ -1,6 +1,6 @@
-import { requireAdmin, currentUser, publicUser } from "./auth";
+import { requireAdmin, requireUser, currentUser, publicUser } from "./auth";
 import { auditAdminAction } from "./adminAudit";
-import { parseContentMode, parsePagination, listPets, serializePet, getPet } from "./pets";
+import { parseContentMode, parsePagination, listPets, serializePet, getPet, getVisiblePet } from "./pets";
 import { slugPattern } from "./constants";
 import { all, first, nowIso } from "../core/db";
 import { HttpError, json, readJsonBody } from "../core/http";
@@ -11,11 +11,24 @@ export async function handleCollections(ctx: AppContext, parts: string[]) {
   const user = await currentUser(ctx);
   const content = parseContentMode(ctx.url.searchParams.get("content"));
   if (ctx.request.method === "GET" && parts.length === 0) return json({ collections: await publicCollections(ctx, content) });
+  if (ctx.request.method === "GET" && parts[0] === "mine" && parts.length === 1) {
+    return json({ collections: await userCollections(ctx, await requireUser(ctx), content) });
+  }
+  if (ctx.request.method === "POST" && parts.length === 0) {
+    return json({ collection: await createUserCollection(ctx, await requireUser(ctx)) }, 201);
+  }
+  if ((ctx.request.method === "PATCH" || ctx.request.method === "DELETE") && parts.length === 1 && slugPattern.test(parts[0])) {
+    const owner = await requireUser(ctx);
+    if (ctx.request.method === "PATCH") return json({ collection: await updateUserCollection(ctx, owner, parts[0]) });
+    await deleteUserCollection(ctx, owner, parts[0]);
+    return json({ ok: true });
+  }
   if (ctx.request.method === "GET" && parts.length === 1 && slugPattern.test(parts[0])) {
     const collection = await collectionRow(ctx, parts[0]);
     if (!collection) return json({ error: "collection not found" }, 404);
     const pets = await collectionPets(ctx, collection.slug, content);
-    return json({ collection: { slug: collection.slug, displayName: collection.display_name, petCount: pets.length }, pets: pets.map((pet) => serializePet(ctx, pet, undefined, undefined, user)) });
+    const petIds = collection.owner_id && user?.id === collection.owner_id ? await collectionPetIds(ctx, collection.slug) : undefined;
+    return json({ collection: collectionSummary(ctx, collection, pets, petIds, user), pets: pets.map((pet) => serializePet(ctx, pet, undefined, undefined, user)) });
   }
   return json({ error: "not found" }, 404);
 }
@@ -126,12 +139,8 @@ export async function handleAdmin(ctx: AppContext, parts: string[]) {
 }
 
 export async function publicCollections(ctx: AppContext, content = "safe") {
-  const rows = await all<CollectionRow>(ctx.env.DB.prepare("select * from collections order by display_name asc, slug asc"));
-  return Promise.all(rows.map(async (row) => {
-    const pets = await collectionPets(ctx, row.slug, content);
-    const topPets = pets.sort((a, b) => (b.like_count - a.like_count) || (b.view_count - a.view_count)).slice(0, 3);
-    return { slug: row.slug, displayName: row.display_name, petCount: pets.length, topPets: topPets.map((pet) => serializePet(ctx, pet)) };
-  }));
+  const rows = await all<CollectionRow>(ctx.env.DB.prepare("select * from collections where owner_id is null order by display_name asc, slug asc"));
+  return Promise.all(rows.map((row) => collectionSummaryForRow(ctx, row, content)));
 }
 
 export async function collectionRow(ctx: AppContext, slug: string) {
@@ -143,16 +152,75 @@ export async function collectionPetIds(ctx: AppContext, slug: string) {
   return rows.map((row) => row.pet_id);
 }
 
-async function collectionPets(ctx: AppContext, slug: string, content: string) {
+export async function collectionPets(ctx: AppContext, slug: string, content: string) {
   const ids = await collectionPetIds(ctx, slug);
   const rows = (await Promise.all(ids.map((id) => getPet(ctx, id)))).filter(Boolean) as PetRow[];
   return rows.filter((row) => content === "all" || !(JSON.parse(row.tags_json) as string[]).includes("nsfw"))
     .sort((a, b) => a.display_name.localeCompare(b.display_name));
 }
 
+async function collectionSummaryForRow(ctx: AppContext, row: CollectionRow, content: string, viewer?: AuthUser | null, includePetIds = false) {
+  const pets = await collectionPets(ctx, row.slug, content);
+  const petIds = includePetIds ? await collectionPetIds(ctx, row.slug) : undefined;
+  return collectionSummary(ctx, row, pets, petIds, viewer);
+}
+
+function collectionSummary(ctx: AppContext, row: CollectionRow, pets: PetRow[], petIds?: string[], viewer?: AuthUser | null) {
+  const topPets = [...pets].sort((a, b) => (b.like_count - a.like_count) || (b.view_count - a.view_count)).slice(0, 3);
+  const ownerId = row.owner_id || null;
+  return {
+    slug: row.slug,
+    displayName: row.display_name,
+    ownerId,
+    editable: Boolean(ownerId && viewer?.id === ownerId),
+    petCount: pets.length,
+    topPets: topPets.map((pet) => serializePet(ctx, pet)),
+    ...(petIds ? { petIds } : {})
+  };
+}
+
 async function adminCollections(ctx: AppContext) {
-  const rows = await all<CollectionRow>(ctx.env.DB.prepare("select * from collections order by display_name asc, slug asc"));
+  const rows = await all<CollectionRow>(ctx.env.DB.prepare("select * from collections where owner_id is null order by display_name asc, slug asc"));
   return Promise.all(rows.map(async (row) => ({ slug: row.slug, displayName: row.display_name, petIds: await collectionPetIds(ctx, row.slug) })));
+}
+
+async function userCollections(ctx: AppContext, user: AuthUser, content: string) {
+  const rows = await all<CollectionRow>(
+    ctx.env.DB.prepare("select * from collections where owner_id = ? order by updated_at desc, display_name asc, slug asc").bind(user.id)
+  );
+  return Promise.all(rows.map((row) => collectionSummaryForRow(ctx, row, content, user, true)));
+}
+
+async function createUserCollection(ctx: AppContext, user: AuthUser) {
+  if (user.isShadowbanned) throw new HttpError("not allowed", 403);
+  const body = await readJsonBody<{ displayName?: unknown; petIds?: unknown }>(ctx.request);
+  const displayName = validateCollectionDisplayName(body.displayName);
+  const petIds = normalizePetIds(body.petIds ?? []);
+  await requireVisiblePets(ctx, user, petIds);
+  const slug = await nextUserCollectionSlug(ctx, displayName);
+  await ctx.env.DB.prepare("insert into collections (slug, display_name, owner_id, updated_at) values (?, ?, ?, ?)")
+    .bind(slug, displayName, user.id, nowIso()).run();
+  await setUserCollectionPets(ctx, slug, petIds);
+  return collectionSummaryForRow(ctx, await collectionRow(ctx, slug) as CollectionRow, "all", user, true);
+}
+
+async function updateUserCollection(ctx: AppContext, user: AuthUser, slug: string) {
+  if (user.isShadowbanned) throw new HttpError("not allowed", 403);
+  const row = await requireOwnedCollection(ctx, user, slug);
+  const body = await readJsonBody<{ displayName?: unknown; petIds?: unknown }>(ctx.request);
+  const displayName = body.displayName == null ? row.display_name : validateCollectionDisplayName(body.displayName);
+  const petIds = body.petIds == null ? undefined : normalizePetIds(body.petIds);
+  if (petIds) await requireVisiblePets(ctx, user, petIds);
+  await ctx.env.DB.prepare("update collections set display_name = ?, updated_at = ? where slug = ?")
+    .bind(displayName, nowIso(), slug).run();
+  if (petIds) await setUserCollectionPets(ctx, slug, petIds);
+  return collectionSummaryForRow(ctx, await collectionRow(ctx, slug) as CollectionRow, "all", user, true);
+}
+
+async function deleteUserCollection(ctx: AppContext, user: AuthUser, slug: string) {
+  if (user.isShadowbanned) throw new HttpError("not allowed", 403);
+  await requireOwnedCollection(ctx, user, slug);
+  await ctx.env.DB.prepare("delete from collections where slug = ? and owner_id = ?").bind(slug, user.id).run();
 }
 
 export async function upsertCollection(ctx: AppContext, input: { slug: string; displayName: string }, replace = true) {
@@ -176,6 +244,12 @@ export async function setCollectionPets(ctx: AppContext, slug: string, petIds: s
   return { slug, displayName: row.display_name, petIds };
 }
 
+async function setUserCollectionPets(ctx: AppContext, slug: string, petIds: string[]) {
+  await ctx.env.DB.prepare("delete from collection_pets where collection_slug = ?").bind(slug).run();
+  for (const petId of petIds) await ctx.env.DB.prepare("insert into collection_pets (collection_slug, pet_id) values (?, ?)").bind(slug, petId).run();
+  await ctx.env.DB.prepare("update collections set updated_at = ? where slug = ?").bind(nowIso(), slug).run();
+}
+
 async function setPetCollections(ctx: AppContext, petId: string, slugs: string[]) {
   if (!await getPet(ctx, petId)) throw new HttpError("pet not found", 404);
   await requireExistingCollections(ctx, slugs);
@@ -194,6 +268,17 @@ function normalizeCollectionSlug(value: unknown) {
   return slug;
 }
 
+async function nextUserCollectionSlug(ctx: AppContext, displayName: string) {
+  const base = normalizeCollectionSlug(displayName);
+  let slug = base;
+  let suffix = 2;
+  while (await collectionRow(ctx, slug)) {
+    slug = `${base}-${suffix}`;
+    suffix += 1;
+  }
+  return slug;
+}
+
 function validateCollectionDisplayName(value: unknown) {
   const displayName = String(value || "").trim().replace(/\s+/g, " ");
   if (!displayName || displayName.length > 80) throw new HttpError("collection display name is required", 400);
@@ -202,7 +287,7 @@ function validateCollectionDisplayName(value: unknown) {
 
 function normalizePetIds(value: unknown) {
   if (!Array.isArray(value)) throw new HttpError("petIds must be an array", 400);
-  return value.map((item) => String(item || "").trim()).filter(Boolean);
+  return [...new Set(value.map((item) => String(item || "").trim()).filter(Boolean))];
 }
 
 function normalizeCollectionSlugs(value: unknown) {
@@ -220,6 +305,18 @@ async function requireExistingCollections(ctx: AppContext, slugs: string[]) {
   for (const slug of slugs) {
     if (!await collectionRow(ctx, slug)) throw new HttpError("one or more collections were not found", 400);
   }
+}
+
+async function requireVisiblePets(ctx: AppContext, user: AuthUser, petIds: string[]) {
+  for (const petId of petIds) {
+    if (!await getVisiblePet(ctx, petId, user)) throw new HttpError("one or more pets were not found", 400);
+  }
+}
+
+async function requireOwnedCollection(ctx: AppContext, user: AuthUser, slug: string) {
+  const row = await collectionRow(ctx, slug);
+  if (!row || row.owner_id !== user.id) throw new HttpError("collection not found", 404);
+  return row;
 }
 
 async function userTarget(ctx: AppContext, value: string) {

--- a/adapters/cloudflare-worker/src/api/share.ts
+++ b/adapters/cloudflare-worker/src/api/share.ts
@@ -1,4 +1,4 @@
-import { collectionRow, publicCollections } from "./collections";
+import { collectionPets, collectionRow } from "./collections";
 import { currentUser, publicUser } from "./auth";
 import { getVisiblePet, listPets } from "./pets";
 import { slugPattern } from "./constants";
@@ -40,15 +40,19 @@ export async function handleEntityShare(ctx: AppContext, kind: "collections" | "
   if (kind === "collections" && id) {
     const collection = await collectionRow(ctx, id);
     if (!collection) return html("<!doctype html><title>Collection not found</title>", 404);
-    const collections = await publicCollections(ctx);
-    const summary = collections.find((item) => item.slug === id);
+    const pets = await collectionPets(ctx, collection.slug, "safe");
+    const featured = pets[0] || null;
+    const staticCollectionImage = `${ctx.env.PUBLIC_APP_ORIGIN}/assets/social/collections/${collection.slug}.png`;
+    const image = collection.owner_id
+      ? featured ? `${ctx.url.origin}/api/pets/${featured.id}/share-image` : `${ctx.env.PUBLIC_APP_ORIGIN}/assets/petshare-social-preview.png`
+      : staticCollectionImage;
     return entityHtml(ctx, {
       title: collection.display_name,
-      description: `${summary?.petCount || 0} pets in ${ctx.env.APP_NAME}`,
+      description: `${pets.length} pets in ${ctx.env.APP_NAME}`,
       canonical: `${ctx.env.PUBLIC_APP_ORIGIN}/#/collections/${collection.slug}`,
       shareUrl: `${ctx.env.PUBLIC_APP_ORIGIN}/collections/${collection.slug}`,
-      image: `${ctx.env.PUBLIC_APP_ORIGIN}/assets/social/collections/${collection.slug}.png`,
-      body: `<h1>${escapeHtml(collection.display_name)}</h1><p>${summary?.petCount || 0} pets</p>`
+      image,
+      body: `<h1>${escapeHtml(collection.display_name)}</h1><p>${pets.length} pets</p>`
     });
   }
   if (kind === "users" && id) {

--- a/adapters/cloudflare-worker/src/core/types.ts
+++ b/adapters/cloudflare-worker/src/core/types.ts
@@ -81,6 +81,7 @@ export type PetRow = {
 export type CollectionRow = {
   slug: string;
   display_name: string;
+  owner_id: string | null;
   created_at: string;
   updated_at: string;
 };

--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -12,6 +12,7 @@ import { usePetEditors } from "../pets/usePetEditors";
 import { usePetMutations } from "../pets/usePetMutations";
 import { useGalleryBrowser } from "../gallery/useGalleryBrowser";
 import { useUserCollections } from "../collections/useUserCollections";
+import { useTheme } from "./useTheme";
 import { refreshAfterAuthRoute, refreshAppSession } from "./appRefreshActions";
 import type {
   AuthSession,
@@ -26,6 +27,7 @@ export type { CollectionSummary, Pet, User } from "../domain/types";
 
 function App() {
   const [route, setRoute] = useState<Route>(() => routeFromHash());
+  const { theme, toggleTheme } = useTheme();
   const { session, user, setUser, apiFetch, applySession, loadMe, refreshSession } = useSessionApi();
   const {
     pets,
@@ -385,7 +387,7 @@ function App() {
   });
 
   const viewProps = {
-    nav: { route, user, onLogout: logout, onSignIn: openAuth, onAccount: openSettings },
+    nav: { route, user, theme, onLogout: logout, onSignIn: openAuth, onAccount: openSettings, onThemeToggle: toggleTheme },
     routes: {
       route, user, session, pets, galleryMeta, loading, query, activeTags, activeSort, activeView, activeKind,
       contentMode, deletingPetId, shadowbanBusyOwnerId, nsfwBusyId, collections, userCollections,

--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -11,6 +11,7 @@ import { useUploadWorkflow } from "../uploads/useUploadWorkflow";
 import { usePetEditors } from "../pets/usePetEditors";
 import { usePetMutations } from "../pets/usePetMutations";
 import { useGalleryBrowser } from "../gallery/useGalleryBrowser";
+import { useUserCollections } from "../collections/useUserCollections";
 import { refreshAfterAuthRoute, refreshAppSession } from "./appRefreshActions";
 import type {
   AuthSession,
@@ -73,6 +74,8 @@ function App() {
     creatorsTotal,
     collections,
     setCollections,
+    userCollections,
+    setUserCollections,
     adminCollections,
     setAdminCollections,
     collectionDetail,
@@ -85,6 +88,7 @@ function App() {
     creatorLoading,
     creatorsLoading,
     collectionsLoading,
+    userCollectionsLoading,
     adminCollectionsLoading,
     collectionDetailLoading,
     loadMine,
@@ -93,6 +97,7 @@ function App() {
     loadCreator,
     loadCreators,
     loadCollections,
+    loadUserCollections,
     loadCollectionDetail,
     loadAdminCollections,
     refreshPrimaryPetLists,
@@ -262,6 +267,20 @@ function App() {
     reconcileTaggedPet,
     reconcilePetCollections
   });
+  const userCollectionActions = useUserCollections({
+    user,
+    session,
+    route,
+    contentMode,
+    apiFetch,
+    userCollections,
+    setUserCollections,
+    setCollectionDetail,
+    setCollectionPets,
+    loadUserCollections,
+    loadCollectionDetail,
+    openAuth
+  });
   async function refreshAfterAuth(nextUser: User, nextSession: AuthSession) {
     await refreshAfterAuthRoute({
       nextUser,
@@ -282,6 +301,7 @@ function App() {
       loadCreator,
       loadCreators,
       loadCollections,
+      loadUserCollections,
       loadCollectionDetail,
       loadAdminCollections
     });
@@ -313,6 +333,7 @@ function App() {
     playgroundPet,
     refresh,
     loadCollections,
+    loadUserCollections,
     setAuthStatus,
     applyGalleryState,
     setLoading,
@@ -335,6 +356,7 @@ function App() {
 
   const { selectContentMode, selectCreatorPage, logout } = useAppNavigationActions({
     route,
+    user,
     session,
     contentMode,
     setContentMode,
@@ -358,6 +380,7 @@ function App() {
     loadCreator,
     loadCreators,
     loadCollections,
+    loadUserCollections,
     loadCollectionDetail
   });
 
@@ -365,10 +388,17 @@ function App() {
     nav: { route, user, onLogout: logout, onSignIn: openAuth, onAccount: openSettings },
     routes: {
       route, user, session, pets, galleryMeta, loading, query, activeTags, activeSort, activeView, activeKind,
-      contentMode, deletingPetId, shadowbanBusyOwnerId, nsfwBusyId, collections, setQuery, selectTag,
+      contentMode, deletingPetId, shadowbanBusyOwnerId, nsfwBusyId, collections, userCollections,
+      userCollectionsLoading, setQuery, selectTag,
       clearTags, selectSort, selectView, selectKind, selectContentMode, selectPage, randomizeGallery,
       submitSearch, likeBusyId, toggleLike, setSharingPet, setPlaygroundPet, setDownloadPet,
       selectVisibleTag, openTagEditor, openCollectionEditor, togglePetNsfw, toggleOwnerShadowban,
+      openPetCollector: userCollectionActions.openPetCollector,
+      openCollectionCreator: userCollectionActions.openCollectionCreator,
+      openUserCollectionEditor: userCollectionActions.openCollectionEditor,
+      deleteUserCollection: userCollectionActions.deleteUserCollection,
+      removePetFromUserCollection: userCollectionActions.removePetFromCollection,
+      startUserCollectionRoom: userCollectionActions.startCollectionRoom,
       deleteUpload, openAuth, favoritePets, favoritesLoading, minePets, mineLoading, deleteStatus,
       uploadState, uploadStatus, uploadBusy, setUploadState, setUploadStatus, submitUpload, creators,
       creatorsTotal, creatorsLoading, collectionsLoading, setAuthMode, setSharingEntity, collectionDetail,
@@ -385,7 +415,23 @@ function App() {
       tagEditorTags, tagEditorKind, tagEditorStatus, tagEditorBusy, setTagEditorKind, toggleTagEditorTag,
       submitTagEditor, closeTagEditor, collectionEditorPet, adminCollections, collectionEditorSlugs,
       collectionEditorStatus, collectionEditorBusy, toggleCollectionEditorSlug, submitCollectionEditor,
-      closeCollectionEditor
+      closeCollectionEditor,
+      userCollectionEditor: userCollectionActions.collectionEditor,
+      userCollectionEditorStatus: userCollectionActions.collectionEditorStatus,
+      userCollectionEditorBusy: userCollectionActions.collectionEditorBusy,
+      setUserCollectionEditorDisplayName: userCollectionActions.setCollectionEditorDisplayName,
+      submitUserCollectionEditor: userCollectionActions.submitCollectionEditor,
+      closeUserCollectionEditor: userCollectionActions.closeCollectionEditor,
+      collectPet: userCollectionActions.collectPet,
+      collectSelectedSlugs: userCollectionActions.collectSelectedSlugs,
+      collectNewName: userCollectionActions.collectNewName,
+      collectStatus: userCollectionActions.collectStatus,
+      collectBusy: userCollectionActions.collectBusy,
+      setCollectNewName: userCollectionActions.setCollectNewName,
+      toggleCollectSlug: userCollectionActions.toggleCollectSlug,
+      submitPetCollector: userCollectionActions.submitPetCollector,
+      closePetCollector: userCollectionActions.closePetCollector,
+      userCollections
     },
     playground: {
       route, user, session, playgroundPet, favoritePets, collections, setPlaygroundPet, setAuthMode, apiFetch

--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -398,6 +398,7 @@ function App() {
       openPetCollector: userCollectionActions.openPetCollector,
       openCollectionCreator: userCollectionActions.openCollectionCreator,
       openUserCollectionEditor: userCollectionActions.openCollectionEditor,
+      openCollectionPetAdder: userCollectionActions.openCollectionPetAdder,
       deleteUserCollection: userCollectionActions.deleteUserCollection,
       removePetFromUserCollection: userCollectionActions.removePetFromCollection,
       startUserCollectionRoom: userCollectionActions.startCollectionRoom,
@@ -433,6 +434,14 @@ function App() {
       toggleCollectSlug: userCollectionActions.toggleCollectSlug,
       submitPetCollector: userCollectionActions.submitPetCollector,
       closePetCollector: userCollectionActions.closePetCollector,
+      collectionPetAdder: userCollectionActions.collectionPetAdder,
+      collectionPetAdderStatus: userCollectionActions.collectionPetAdderStatus,
+      collectionPetAdderLoading: userCollectionActions.collectionPetAdderLoading,
+      collectionPetAdderBusyId: userCollectionActions.collectionPetAdderBusyId,
+      setCollectionPetAdderQuery: userCollectionActions.setCollectionPetAdderQuery,
+      searchCollectionPetAdder: userCollectionActions.searchCollectionPetAdder,
+      addPetToCollection: userCollectionActions.addPetToCollection,
+      closeCollectionPetAdder: userCollectionActions.closeCollectionPetAdder,
       userCollections
     },
     playground: {

--- a/src/app/AppChrome.tsx
+++ b/src/app/AppChrome.tsx
@@ -7,15 +7,19 @@ import { Icon } from "../ui/Icon";
 export function AppNav({
   route,
   user,
+  theme,
   onLogout,
   onSignIn,
-  onAccount
+  onAccount,
+  onThemeToggle
 }: {
   route: Route;
   user: User | null;
+  theme: "light" | "dark";
   onLogout: () => void;
   onSignIn: () => void;
   onAccount: () => void;
+  onThemeToggle: () => void;
 }) {
   const [accountMenuOpen, setAccountMenuOpen] = useState(false);
   const accountMenuRef = useRef<HTMLDivElement | null>(null);
@@ -68,6 +72,15 @@ export function AppNav({
         </a>
       </nav>
       <div className="accountAction">
+        <button
+          className="themeToggle"
+          type="button"
+          aria-label={theme === "dark" ? "Switch to light theme" : "Switch to dark theme"}
+          title={theme === "dark" ? "Light theme" : "Dark theme"}
+          onClick={onThemeToggle}
+        >
+          <Icon name={theme === "dark" ? "sun" : "moon"} size={14} />
+        </button>
         {user ? (
           <div
             ref={accountMenuRef}

--- a/src/app/AppChrome.tsx
+++ b/src/app/AppChrome.tsx
@@ -57,11 +57,10 @@ export function AppNav({
           Gallery
         </a>
         <a
-          className={`navCollectionsLink ${route.name === "collections" || route.name === "collection" ? "active" : ""}`}
+          className={route.name === "collections" || route.name === "collection" ? "active" : ""}
           href="#/collections"
         >
           Collections
-          <span className="navNewBadge">NEW</span>
         </a>
         <a className={route.name === "creators" ? "active" : ""} href="#/creators">
           Creators

--- a/src/app/AppDialogs.tsx
+++ b/src/app/AppDialogs.tsx
@@ -1,10 +1,11 @@
 import type { Dispatch, FormEvent, SetStateAction } from "react";
 import { type AdminCollection } from "../admin/AdminPage";
 import { AuthModal, AccountSettingsModal } from "../auth/AuthModals";
+import { PetCollectorModal, UserCollectionEditorModal } from "../collections/UserCollectionModals";
 import { DownloadModal } from "../downloads/DownloadModal";
 import { PetCollectionsModal, TagEditorModal } from "../pets/PetManagementModals";
 import { EntityShareModal, ShareModal } from "../share/ShareModals";
-import type { EditablePetKind, EntityShareTarget, Pet } from "../domain/types";
+import type { CollectionSummary, EditablePetKind, EntityShareTarget, Pet } from "../domain/types";
 import type { TagName } from "../domain/config";
 
 export function AppDialogs({
@@ -50,7 +51,23 @@ export function AppDialogs({
   collectionEditorBusy,
   toggleCollectionEditorSlug,
   submitCollectionEditor,
-  closeCollectionEditor
+  closeCollectionEditor,
+  userCollectionEditor,
+  userCollectionEditorStatus,
+  userCollectionEditorBusy,
+  setUserCollectionEditorDisplayName,
+  submitUserCollectionEditor,
+  closeUserCollectionEditor,
+  collectPet,
+  collectSelectedSlugs,
+  collectNewName,
+  collectStatus,
+  collectBusy,
+  setCollectNewName,
+  toggleCollectSlug,
+  submitPetCollector,
+  closePetCollector,
+  userCollections
 }: {
   authOpen: boolean;
   authMode: "login" | "register";
@@ -95,6 +112,22 @@ export function AppDialogs({
   toggleCollectionEditorSlug: (slug: string) => void;
   submitCollectionEditor: (event: FormEvent) => void | Promise<void>;
   closeCollectionEditor: () => void;
+  userCollectionEditor: { mode: "create" | "edit"; collection: CollectionSummary | null; displayName: string } | null;
+  userCollectionEditorStatus: string;
+  userCollectionEditorBusy: boolean;
+  setUserCollectionEditorDisplayName: (displayName: string) => void;
+  submitUserCollectionEditor: (event: FormEvent) => void | Promise<void>;
+  closeUserCollectionEditor: () => void;
+  collectPet: Pet | null;
+  collectSelectedSlugs: string[];
+  collectNewName: string;
+  collectStatus: string;
+  collectBusy: boolean;
+  setCollectNewName: Dispatch<SetStateAction<string>>;
+  toggleCollectSlug: (slug: string) => void;
+  submitPetCollector: (event: FormEvent) => void | Promise<void>;
+  closePetCollector: () => void;
+  userCollections: CollectionSummary[];
 }) {
   return (
     <>
@@ -154,6 +187,32 @@ export function AppDialogs({
           onToggle={toggleCollectionEditorSlug}
           onSubmit={submitCollectionEditor}
           onClose={closeCollectionEditor}
+        />
+      )}
+
+      {userCollectionEditor && (
+        <UserCollectionEditorModal
+          editor={userCollectionEditor}
+          status={userCollectionEditorStatus}
+          busy={userCollectionEditorBusy}
+          onDisplayName={setUserCollectionEditorDisplayName}
+          onSubmit={submitUserCollectionEditor}
+          onClose={closeUserCollectionEditor}
+        />
+      )}
+
+      {collectPet && (
+        <PetCollectorModal
+          pet={collectPet}
+          collections={userCollections}
+          selectedSlugs={collectSelectedSlugs}
+          newName={collectNewName}
+          status={collectStatus}
+          busy={collectBusy}
+          onToggle={toggleCollectSlug}
+          onNewName={setCollectNewName}
+          onSubmit={submitPetCollector}
+          onClose={closePetCollector}
         />
       )}
     </>

--- a/src/app/AppDialogs.tsx
+++ b/src/app/AppDialogs.tsx
@@ -1,7 +1,8 @@
 import type { Dispatch, FormEvent, SetStateAction } from "react";
 import { type AdminCollection } from "../admin/AdminPage";
 import { AuthModal, AccountSettingsModal } from "../auth/AuthModals";
-import { PetCollectorModal, UserCollectionEditorModal } from "../collections/UserCollectionModals";
+import { CollectionPetAdderModal, PetCollectorModal, UserCollectionEditorModal } from "../collections/UserCollectionModals";
+import type { CollectionPetAdderState } from "../collections/useUserCollections";
 import { DownloadModal } from "../downloads/DownloadModal";
 import { PetCollectionsModal, TagEditorModal } from "../pets/PetManagementModals";
 import { EntityShareModal, ShareModal } from "../share/ShareModals";
@@ -67,6 +68,14 @@ export function AppDialogs({
   toggleCollectSlug,
   submitPetCollector,
   closePetCollector,
+  collectionPetAdder,
+  collectionPetAdderStatus,
+  collectionPetAdderLoading,
+  collectionPetAdderBusyId,
+  setCollectionPetAdderQuery,
+  searchCollectionPetAdder,
+  addPetToCollection,
+  closeCollectionPetAdder,
   userCollections
 }: {
   authOpen: boolean;
@@ -127,6 +136,14 @@ export function AppDialogs({
   toggleCollectSlug: (slug: string) => void;
   submitPetCollector: (event: FormEvent) => void | Promise<void>;
   closePetCollector: () => void;
+  collectionPetAdder: CollectionPetAdderState | null;
+  collectionPetAdderStatus: string;
+  collectionPetAdderLoading: boolean;
+  collectionPetAdderBusyId: string;
+  setCollectionPetAdderQuery: (query: string) => void;
+  searchCollectionPetAdder: (event: FormEvent) => void | Promise<void>;
+  addPetToCollection: (pet: Pet) => void | Promise<void>;
+  closeCollectionPetAdder: () => void;
   userCollections: CollectionSummary[];
 }) {
   return (
@@ -213,6 +230,19 @@ export function AppDialogs({
           onNewName={setCollectNewName}
           onSubmit={submitPetCollector}
           onClose={closePetCollector}
+        />
+      )}
+
+      {collectionPetAdder && (
+        <CollectionPetAdderModal
+          adder={collectionPetAdder}
+          status={collectionPetAdderStatus}
+          loading={collectionPetAdderLoading}
+          busyPetId={collectionPetAdderBusyId}
+          onQuery={setCollectionPetAdderQuery}
+          onSearch={searchCollectionPetAdder}
+          onAdd={addPetToCollection}
+          onClose={closeCollectionPetAdder}
         />
       )}
     </>

--- a/src/app/AppRoutes.tsx
+++ b/src/app/AppRoutes.tsx
@@ -42,6 +42,8 @@ export function AppRoutes({
   shadowbanBusyOwnerId,
   nsfwBusyId,
   collections,
+  userCollections,
+  userCollectionsLoading,
   setQuery,
   selectTag,
   clearTags,
@@ -60,6 +62,12 @@ export function AppRoutes({
   selectVisibleTag,
   openTagEditor,
   openCollectionEditor,
+  openPetCollector,
+  openCollectionCreator,
+  openUserCollectionEditor,
+  deleteUserCollection,
+  removePetFromUserCollection,
+  startUserCollectionRoom,
   togglePetNsfw,
   toggleOwnerShadowban,
   deleteUpload,
@@ -141,6 +149,7 @@ export function AppRoutes({
           onTagClick={selectVisibleTag}
           onEditTags={openTagEditor}
           onManageCollections={openCollectionEditor}
+          onCollect={openPetCollector}
           onToggleNsfw={togglePetNsfw}
           onShadowbanOwner={toggleOwnerShadowban}
           onDelete={deleteUpload}
@@ -166,6 +175,7 @@ export function AppRoutes({
           onTagClick={selectVisibleTag}
           onEditTags={openTagEditor}
           onManageCollections={openCollectionEditor}
+          onCollect={openPetCollector}
           onToggleNsfw={togglePetNsfw}
           onShadowbanOwner={toggleOwnerShadowban}
           onDelete={deleteUpload}
@@ -209,10 +219,28 @@ export function AppRoutes({
       {route.name === "collections" && (
         <CollectionsPageWithPresence
           collections={collections}
+          userCollections={userCollections}
           loading={collectionsLoading}
+          userCollectionsLoading={userCollectionsLoading}
           signedIn={!!user}
           session={session}
           onSignIn={() => setAuthMode("login")}
+          onCreateCollection={openCollectionCreator}
+          onEditCollection={openUserCollectionEditor}
+          onDeleteCollection={deleteUserCollection}
+          onStartUserCollectionRoom={startUserCollectionRoom}
+          onShareCollection={(collection) => {
+            const subtitle = `${collection.petCount} ${collection.petCount === 1 ? "pet" : "pets"} · custom collection`;
+            setSharingEntity({
+              kind: "collection",
+              title: collection.displayName,
+              subtitle,
+              shareUrl: collectionShareUrl(collection),
+              imageUrl: collectionPreviewImage(collection),
+              shareText: `${collection.displayName} on ${APP_NAME}`,
+              ariaLabel: `Share ${collection.displayName}`
+            });
+          }}
           onShareRoom={(collection) => {
             const subtitle = `${collection.petCount} ${collection.petCount === 1 ? "pet" : "pets"} · permanent playground room`;
             setSharingEntity({
@@ -220,7 +248,7 @@ export function AppRoutes({
               title: `Playground · ${collection.displayName}`,
               subtitle,
               shareUrl: collectionPlayShareUrl(collection),
-              imageUrl: collectionCompositeUrl(collection.slug),
+              imageUrl: collectionPreviewImage(collection),
               shareText: `Join the ${collection.displayName} playground on ${APP_NAME}`,
               ariaLabel: `Share ${collection.displayName} playground`
             });
@@ -252,7 +280,9 @@ export function AppRoutes({
               title: collectionDetail.displayName,
               subtitle,
               shareUrl: collectionShareUrl(collectionDetail),
-              imageUrl: collectionCompositeUrl(collectionDetail.slug),
+              imageUrl: collectionDetail.ownerId
+                ? (collectionPets[0]?.shareImageUrl || collectionCompositeUrl(collectionDetail.slug))
+                : collectionCompositeUrl(collectionDetail.slug),
               shareText: `${collectionDetail.displayName} on ${APP_NAME}`,
               ariaLabel: `Share ${collectionDetail.displayName}`
             });
@@ -261,6 +291,9 @@ export function AppRoutes({
           onTagClick={selectVisibleTag}
           onEditTags={openTagEditor}
           onManageCollections={openCollectionEditor}
+          onCollect={openPetCollector}
+          onRemoveFromUserCollection={collectionDetail?.editable ? (pet) => removePetFromUserCollection(collectionDetail, pet) : undefined}
+          onStartRoom={collectionDetail?.ownerId ? () => startUserCollectionRoom(collectionDetail, collectionPets[0]?.id) : undefined}
           onToggleNsfw={togglePetNsfw}
           onShadowbanOwner={toggleOwnerShadowban}
           onDelete={deleteUpload}
@@ -321,6 +354,7 @@ export function AppRoutes({
           onTagClick={selectVisibleTag}
           onEditTags={openTagEditor}
           onManageCollections={openCollectionEditor}
+          onCollect={openPetCollector}
           onToggleNsfw={togglePetNsfw}
           onShadowbanOwner={toggleOwnerShadowban}
           onDelete={deleteUpload}
@@ -353,6 +387,7 @@ export function AppRoutes({
               onSignIn={openAuth}
               onEditTags={openTagEditor}
               onManageCollections={openCollectionEditor}
+              onCollect={openPetCollector}
               onToggleNsfw={togglePetNsfw}
               onShadowbanOwner={toggleOwnerShadowban}
               onDelete={deleteUpload}
@@ -362,4 +397,10 @@ export function AppRoutes({
       )}
     </>
   );
+}
+
+function collectionPreviewImage(collection: { slug: string; ownerId?: string | null; topPets?: Array<{ shareImageUrl: string }> }) {
+  return collection.ownerId
+    ? (collection.topPets?.[0]?.shareImageUrl || collectionCompositeUrl(collection.slug))
+    : collectionCompositeUrl(collection.slug);
 }

--- a/src/app/AppRoutes.tsx
+++ b/src/app/AppRoutes.tsx
@@ -65,6 +65,7 @@ export function AppRoutes({
   openPetCollector,
   openCollectionCreator,
   openUserCollectionEditor,
+  openCollectionPetAdder,
   deleteUserCollection,
   removePetFromUserCollection,
   startUserCollectionRoom,
@@ -292,6 +293,7 @@ export function AppRoutes({
           onEditTags={openTagEditor}
           onManageCollections={openCollectionEditor}
           onCollect={openPetCollector}
+          onAddPet={collectionDetail?.editable ? openCollectionPetAdder : undefined}
           onRemoveFromUserCollection={collectionDetail?.editable ? (pet) => removePetFromUserCollection(collectionDetail, pet) : undefined}
           onStartRoom={collectionDetail?.ownerId ? () => startUserCollectionRoom(collectionDetail, collectionPets[0]?.id) : undefined}
           onToggleNsfw={togglePetNsfw}

--- a/src/app/AppRoutes.types.ts
+++ b/src/app/AppRoutes.types.ts
@@ -61,6 +61,7 @@ export type AppRoutesProps = {
   openPetCollector: (pet: Pet) => void | Promise<void>;
   openCollectionCreator: () => void | Promise<void>;
   openUserCollectionEditor: (collection: CollectionSummary) => void | Promise<void>;
+  openCollectionPetAdder: (collection: Omit<CollectionSummary, "topPets">) => void | Promise<void>;
   deleteUserCollection: (collection: CollectionSummary) => void | Promise<void>;
   removePetFromUserCollection: (collection: Omit<CollectionSummary, "topPets">, pet: Pet) => void | Promise<void>;
   startUserCollectionRoom: (collection: Omit<CollectionSummary, "topPets"> & { topPets?: CollectionSummary["topPets"] }, petId?: string) => void | Promise<void>;

--- a/src/app/AppRoutes.types.ts
+++ b/src/app/AppRoutes.types.ts
@@ -38,6 +38,8 @@ export type AppRoutesProps = {
   shadowbanBusyOwnerId: string;
   nsfwBusyId: string;
   collections: CollectionSummary[];
+  userCollections: CollectionSummary[];
+  userCollectionsLoading: boolean;
   setQuery: SetState<string>;
   selectTag: (tag: TagName) => void | Promise<void>;
   clearTags: () => void | Promise<void>;
@@ -56,6 +58,12 @@ export type AppRoutesProps = {
   selectVisibleTag: (tag: TagName, sourceTags: string[]) => void | Promise<void>;
   openTagEditor: (pet: Pet) => void;
   openCollectionEditor: (pet: Pet) => void | Promise<void>;
+  openPetCollector: (pet: Pet) => void | Promise<void>;
+  openCollectionCreator: () => void | Promise<void>;
+  openUserCollectionEditor: (collection: CollectionSummary) => void | Promise<void>;
+  deleteUserCollection: (collection: CollectionSummary) => void | Promise<void>;
+  removePetFromUserCollection: (collection: Omit<CollectionSummary, "topPets">, pet: Pet) => void | Promise<void>;
+  startUserCollectionRoom: (collection: Omit<CollectionSummary, "topPets"> & { topPets?: CollectionSummary["topPets"] }, petId?: string) => void | Promise<void>;
   togglePetNsfw: (pet: Pet) => void | Promise<void>;
   toggleOwnerShadowban: (pet: Pet) => void | Promise<void>;
   deleteUpload: (pet: Pet) => void | Promise<void>;

--- a/src/app/appRefreshActions.ts
+++ b/src/app/appRefreshActions.ts
@@ -31,6 +31,7 @@ export async function refreshAfterAuthRoute({
   loadCreator,
   loadCreators,
   loadCollections,
+  loadUserCollections,
   loadCollectionDetail,
   loadAdminCollections
 }: {
@@ -52,6 +53,7 @@ export async function refreshAfterAuthRoute({
   loadCreator: (id: string, page?: number, authSession?: AuthSession | null, content?: ContentMode) => Promise<void>;
   loadCreators: (authSession?: AuthSession | null, content?: ContentMode) => Promise<void>;
   loadCollections: (authSession?: AuthSession | null, content?: ContentMode) => Promise<void>;
+  loadUserCollections: (currentUser?: User | null, authSession?: AuthSession | null, content?: ContentMode) => Promise<void>;
   loadCollectionDetail: (slug: string, authSession?: AuthSession | null, content?: ContentMode) => Promise<void>;
   loadAdminCollections: (authSession?: AuthSession | null, currentUser?: User | null) => Promise<void>;
 }) {
@@ -63,7 +65,12 @@ export async function refreshAfterAuthRoute({
   if (route.name === "favorites") await loadFavorites(nextUser, nextSession);
   if (route.name === "user") await loadCreator(route.id, creatorMeta.page, nextSession, contentMode);
   if (route.name === "creators") await loadCreators(nextSession, contentMode);
-  if (route.name === "collections") await loadCollections(nextSession, contentMode);
+  if (route.name === "collections") {
+    await Promise.all([
+      loadCollections(nextSession, contentMode),
+      loadUserCollections(nextUser, nextSession, contentMode)
+    ]);
+  }
   if (route.name === "collection") await loadCollectionDetail(route.slug, nextSession, contentMode);
   if (nextUser.isAdmin && route.name === "admin") await loadAdminCollections(nextSession);
 }

--- a/src/app/base-tokens.css
+++ b/src/app/base-tokens.css
@@ -6,6 +6,9 @@
   --surface: #ffffff;
   --surface-warm: #f4f2eb;
   --surface-soft: #efede5;
+  --nav-bg: rgba(248, 246, 240, 0.88);
+  --noise-opacity: 0.035;
+  --noise-blend: multiply;
 
   --ink: #0f0f0e;
   --foreground: #1c1c1a;
@@ -50,6 +53,39 @@
   text-rendering: optimizeLegibility;
 }
 
+html[data-theme="dark"] {
+  --bg: #10110f;
+  --surface: #191a16;
+  --surface-warm: #202017;
+  --surface-soft: #26261d;
+  --nav-bg: rgba(16, 17, 15, 0.9);
+  --noise-opacity: 0.08;
+  --noise-blend: screen;
+
+  --ink: #fbf8eb;
+  --foreground: #eeeada;
+  --muted: #aaa48f;
+  --subtle: #7d7664;
+
+  --border: #343226;
+  --border-soft: #28271e;
+  --border-strong: #45412f;
+
+  --accent: #a3e635;
+  --accent-deep: #84cc16;
+  --accent-soft: rgba(163, 230, 53, 0.16);
+  --accent-glow: rgba(163, 230, 53, 0.18);
+  --danger: #fb7185;
+
+  --tile-grid: rgba(219, 211, 173, 0.18);
+  --tile-bg: #171813;
+
+  --shadow-sm: 0 1px 2px rgba(0, 0, 0, 0.28);
+  --shadow-md: 0 8px 18px -10px rgba(0, 0, 0, 0.5);
+  --shadow-lg: 0 28px 60px -26px rgba(0, 0, 0, 0.68);
+  --shadow-modal: 0 60px 120px -42px rgba(0, 0, 0, 0.84);
+}
+
 * {
   box-sizing: border-box;
 }
@@ -75,8 +111,8 @@ body::before {
   z-index: 0;
   pointer-events: none;
   background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='240' height='240' viewBox='0 0 240 240'%3E%3Cfilter id='n'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.9' numOctaves='2' stitchTiles='stitch'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23n)' opacity='0.5'/%3E%3C/svg%3E");
-  opacity: 0.035;
-  mix-blend-mode: multiply;
+  opacity: var(--noise-opacity);
+  mix-blend-mode: var(--noise-blend);
 }
 
 button,

--- a/src/app/base-tokens.css
+++ b/src/app/base-tokens.css
@@ -7,6 +7,8 @@
   --surface-warm: #f4f2eb;
   --surface-soft: #efede5;
   --nav-bg: rgba(248, 246, 240, 0.88);
+  --nav-action-bg: rgba(255, 255, 255, 0.78);
+  --nav-action-bg-hover: #ffffff;
   --noise-opacity: 0.035;
   --noise-blend: multiply;
 
@@ -24,9 +26,29 @@
   --accent-soft: #ecfccb;
   --accent-glow: rgba(101, 163, 13, 0.16);
   --danger: #d92d20;
+  --danger-bg: transparent;
+  --danger-bg-hover: #fff3f0;
+  --danger-border: #e6b5aa;
+  --danger-border-hover: #9f2f22;
+  --danger-fg: #9f2f22;
+  --danger-fg-hover: #7f1d1d;
+  --primary-bg: var(--ink);
+  --primary-bg-hover: #1f1f1c;
+  --primary-fg: var(--surface);
+  --terminal-bg: #11110f;
+  --terminal-border: #2a2926;
+  --terminal-fg: #e8e6e0;
 
   --tile-grid: rgba(180, 174, 158, 0.4);
   --tile-bg: #ffffff;
+  --preview-surface: #ffffff;
+  --preview-halo: rgba(228, 225, 217, 0.74);
+  --preview-soft-top: #fffdf5;
+  --preview-ground: rgba(16, 16, 15, 0.06);
+  --floating-control-bg: rgba(255, 255, 255, 0.92);
+  --floating-control-bg-hover: #ffffff;
+  --rail-bg: rgba(255, 255, 255, 0.72);
+  --inset-highlight: rgba(255, 255, 255, 0.55);
 
   --font-sans: "Cabinet Grotesk", -apple-system, BlinkMacSystemFont, "Helvetica Neue", sans-serif;
   --font-mono: "JetBrains Mono", ui-monospace, "SF Mono", Menlo, Consolas, monospace;
@@ -59,6 +81,8 @@ html[data-theme="dark"] {
   --surface-warm: #202017;
   --surface-soft: #26261d;
   --nav-bg: rgba(16, 17, 15, 0.9);
+  --nav-action-bg: rgba(31, 32, 25, 0.78);
+  --nav-action-bg-hover: #26261d;
   --noise-opacity: 0.08;
   --noise-blend: screen;
 
@@ -76,9 +100,29 @@ html[data-theme="dark"] {
   --accent-soft: rgba(163, 230, 53, 0.16);
   --accent-glow: rgba(163, 230, 53, 0.18);
   --danger: #fb7185;
+  --danger-bg: rgba(251, 113, 133, 0.08);
+  --danger-bg-hover: rgba(251, 113, 133, 0.14);
+  --danger-border: rgba(251, 113, 133, 0.24);
+  --danger-border-hover: rgba(251, 113, 133, 0.42);
+  --danger-fg: #fda4af;
+  --danger-fg-hover: #ffe4e6;
+  --primary-bg: color-mix(in srgb, var(--accent) 26%, var(--surface-soft));
+  --primary-bg-hover: color-mix(in srgb, var(--accent) 34%, var(--surface-soft));
+  --primary-fg: var(--ink);
+  --terminal-bg: #10110d;
+  --terminal-border: #303424;
+  --terminal-fg: #e7e3d5;
 
   --tile-grid: rgba(219, 211, 173, 0.18);
   --tile-bg: #171813;
+  --preview-surface: #202118;
+  --preview-halo: rgba(98, 105, 76, 0.42);
+  --preview-soft-top: #24251b;
+  --preview-ground: rgba(0, 0, 0, 0.24);
+  --floating-control-bg: rgba(25, 26, 22, 0.92);
+  --floating-control-bg-hover: #26261d;
+  --rail-bg: rgba(25, 26, 22, 0.74);
+  --inset-highlight: rgba(255, 255, 255, 0.08);
 
   --shadow-sm: 0 1px 2px rgba(0, 0, 0, 0.28);
   --shadow-md: 0 8px 18px -10px rgba(0, 0, 0, 0.5);

--- a/src/app/controls.css
+++ b/src/app/controls.css
@@ -35,16 +35,16 @@
 }
 
 .btnPrimary {
-  border-color: var(--ink);
-  background: var(--ink);
-  color: var(--surface);
+  border-color: var(--primary-bg);
+  background: var(--primary-bg);
+  color: var(--primary-fg);
   box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.08);
 }
 
 .btnPrimary:hover:not(:disabled) {
-  border-color: var(--ink);
-  background: #1f1f1c;
-  color: var(--surface);
+  border-color: var(--primary-bg-hover);
+  background: var(--primary-bg-hover);
+  color: var(--primary-fg);
 }
 
 .btnGhost {
@@ -68,14 +68,15 @@
 }
 
 .btnDanger {
-  border-color: #e6b5aa;
-  color: #9f2f22;
+  border-color: var(--danger-border);
+  background: var(--danger-bg);
+  color: var(--danger-fg);
 }
 
 .btnDanger:hover:not(:disabled) {
-  border-color: #9f2f22;
-  background: #fff3f0;
-  color: #7f1d1d;
+  border-color: var(--danger-border-hover);
+  background: var(--danger-bg-hover);
+  color: var(--danger-fg-hover);
 }
 
 .btnSm {

--- a/src/app/shell.css
+++ b/src/app/shell.css
@@ -19,7 +19,7 @@
   min-height: 60px;
   padding: 12px 0;
   border-bottom: 1px solid var(--border-strong);
-  background: rgba(248, 246, 240, 0.88);
+  background: var(--nav-bg);
   backdrop-filter: saturate(140%) blur(14px);
   -webkit-backdrop-filter: saturate(140%) blur(14px);
 }
@@ -257,6 +257,28 @@
 }
 
 .appFooter .footerSocialLinks a:active {
+  transform: translateY(1px);
+}
+
+.themeToggle {
+  display: inline-grid;
+  place-items: center;
+  width: 34px;
+  height: 34px;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  background: var(--surface);
+  color: var(--muted);
+  transition: transform 160ms var(--ease-out), border-color 180ms var(--ease-out), color 180ms var(--ease-out), background 180ms var(--ease-out);
+}
+
+.themeToggle:hover {
+  border-color: var(--border-strong);
+  background: var(--surface-soft);
+  color: var(--ink);
+}
+
+.themeToggle:active {
   transform: translateY(1px);
 }
 

--- a/src/app/shell.css
+++ b/src/app/shell.css
@@ -184,23 +184,6 @@
   transform: scaleX(0);
 }
 
-.navLinks .navCollectionsLink {
-  padding-right: 24px;
-}
-
-.navNewBadge {
-  position: absolute;
-  top: 3px;
-  right: 6px;
-  color: var(--danger);
-  font-family: var(--font-mono);
-  font-size: 7px;
-  font-weight: 700;
-  line-height: 1;
-  letter-spacing: 0;
-  pointer-events: none;
-}
-
 .navLinks .navUploadLink {
   gap: 5px;
   margin-left: 10px;

--- a/src/app/styles.css
+++ b/src/app/styles.css
@@ -1,4 +1,5 @@
 @import "./base.css";
+@import "../collections/user-collections.css";
 @import "../gallery/gallery.css";
 @import "../pets/pet-surfaces.css";
 @import "../uploads/uploads.css";

--- a/src/app/surfaces.css
+++ b/src/app/surfaces.css
@@ -41,6 +41,13 @@
   transition: color 200ms var(--ease-out), background 200ms var(--ease-out);
 }
 
+.accountAction > .accountButton {
+  border: 1px solid var(--border);
+  background: var(--nav-action-bg);
+  color: var(--ink);
+  box-shadow: inset 0 1px 0 var(--inset-highlight);
+}
+
 .accountButton::before {
   content: "";
   position: absolute;
@@ -57,6 +64,11 @@
 .accountButton:hover {
   color: var(--ink);
   background: transparent;
+}
+
+.accountAction > .accountButton:hover {
+  border-color: var(--border-strong);
+  background: var(--nav-action-bg-hover);
 }
 
 .accountButton:hover::before {

--- a/src/app/useAppEntityData.ts
+++ b/src/app/useAppEntityData.ts
@@ -78,6 +78,7 @@ export function useAppEntityData({
   const [creators, setCreators] = useState<CreatorLeaderboardItem[]>([]);
   const [creatorsTotal, setCreatorsTotal] = useState(0);
   const [collections, setCollections] = useState<Array<CollectionSummary>>([]);
+  const [userCollections, setUserCollections] = useState<Array<CollectionSummary>>([]);
   const [adminCollections, setAdminCollections] = useState<Array<AdminCollection>>([]);
   const [collectionDetail, setCollectionDetail] = useState<Omit<CollectionSummary, "topPets"> | null>(null);
   const [collectionPets, setCollectionPets] = useState<Array<Pet>>([]);
@@ -87,6 +88,7 @@ export function useAppEntityData({
   const [creatorLoading, setCreatorLoading] = useState(false);
   const [creatorsLoading, setCreatorsLoading] = useState(false);
   const [collectionsLoading, setCollectionsLoading] = useState(false);
+  const [userCollectionsLoading, setUserCollectionsLoading] = useState(false);
   const [adminCollectionsLoading, setAdminCollectionsLoading] = useState(false);
   const [collectionDetailLoading, setCollectionDetailLoading] = useState(false);
 
@@ -202,6 +204,28 @@ export function useAppEntityData({
     }
   }
 
+  async function loadUserCollections(currentUser = user, authSession = session, content = contentMode) {
+    if (!currentUser) {
+      setUserCollections([]);
+      return;
+    }
+    setUserCollectionsLoading(true);
+    try {
+      const params = new URLSearchParams();
+      if (content === "all") {
+        params.set("content", "all");
+      }
+      const suffix = params.toString() ? `?${params}` : "";
+      const body = await readJson<CollectionsResponse>(await apiFetch(`/api/collections/mine${suffix}`, {}, authSession));
+      setUserCollections(body.collections.map((collection) => ({
+        ...collection,
+        topPets: collection.topPets.map(normalizePet)
+      })));
+    } finally {
+      setUserCollectionsLoading(false);
+    }
+  }
+
   async function loadCollectionDetail(slug: string, authSession = session, content = contentMode) {
     setCollectionDetailLoading(true);
     try {
@@ -256,7 +280,7 @@ export function useAppEntityData({
       refreshes.push(loadCreators(authSession, contentMode));
     }
     if (route.name === "collections") {
-      refreshes.push(loadCollections(authSession, contentMode));
+      refreshes.push(loadCollections(authSession, contentMode), loadUserCollections(currentUser, authSession, contentMode));
     }
     if (route.name === "collection") {
       refreshes.push(loadCollectionDetail(route.slug, authSession, contentMode));
@@ -282,6 +306,8 @@ export function useAppEntityData({
     creatorsTotal,
     collections,
     setCollections,
+    userCollections,
+    setUserCollections,
     adminCollections,
     setAdminCollections,
     collectionDetail,
@@ -294,6 +320,7 @@ export function useAppEntityData({
     creatorLoading,
     creatorsLoading,
     collectionsLoading,
+    userCollectionsLoading,
     adminCollectionsLoading,
     collectionDetailLoading,
     loadMine,
@@ -302,6 +329,7 @@ export function useAppEntityData({
     loadCreator,
     loadCreators,
     loadCollections,
+    loadUserCollections,
     loadCollectionDetail,
     loadAdminCollections,
     refreshPrimaryPetLists,

--- a/src/app/useAppNavigationActions.ts
+++ b/src/app/useAppNavigationActions.ts
@@ -26,6 +26,7 @@ type LoadGallery = (
 
 export function useAppNavigationActions({
   route,
+  user,
   session,
   contentMode,
   setContentMode,
@@ -49,9 +50,11 @@ export function useAppNavigationActions({
   loadCreator,
   loadCreators,
   loadCollections,
+  loadUserCollections,
   loadCollectionDetail
 }: {
   route: Route;
+  user: User | null;
   session: AuthSession | null;
   contentMode: ContentMode;
   setContentMode: Dispatch<SetStateAction<ContentMode>>;
@@ -83,6 +86,7 @@ export function useAppNavigationActions({
   loadCreator: (id: string, page?: number, authSession?: AuthSession | null, content?: ContentMode) => Promise<void>;
   loadCreators: (authSession?: AuthSession | null, content?: ContentMode) => Promise<void>;
   loadCollections: (authSession?: AuthSession | null, content?: ContentMode) => Promise<void>;
+  loadUserCollections: (currentUser?: User | null, authSession?: AuthSession | null, content?: ContentMode) => Promise<void>;
   loadCollectionDetail: (slug: string, authSession?: AuthSession | null, content?: ContentMode) => Promise<void>;
 }) {
   async function selectContentMode(mode: ContentMode) {
@@ -108,7 +112,10 @@ export function useAppNavigationActions({
       await loadCreators(session, mode);
     }
     if (route.name === "collections") {
-      await loadCollections(session, mode);
+      await Promise.all([
+        loadCollections(session, mode),
+        loadUserCollections(user, session, mode)
+      ]);
     }
     if (route.name === "collection") {
       await loadCollectionDetail(route.slug, session, mode);

--- a/src/app/useAppRouteEffects.ts
+++ b/src/app/useAppRouteEffects.ts
@@ -31,6 +31,7 @@ export function useAppRouteEffects({
   playgroundPet,
   refresh,
   loadCollections,
+  loadUserCollections,
   setAuthStatus,
   applyGalleryState,
   setLoading,
@@ -57,6 +58,7 @@ export function useAppRouteEffects({
   playgroundPet: Pet | null;
   refresh: (authSession?: AuthSession | null) => Promise<void>;
   loadCollections: (authSession?: AuthSession | null, content?: "safe" | "all") => Promise<void>;
+  loadUserCollections: (currentUser?: User | null, authSession?: AuthSession | null, content?: "safe" | "all") => Promise<void>;
   setAuthStatus: Dispatch<SetStateAction<string>>;
   applyGalleryState: (nextState: ReturnType<typeof galleryUrlStateFromHash>) => void;
   setLoading: Dispatch<SetStateAction<boolean>>;
@@ -122,6 +124,9 @@ export function useAppRouteEffects({
       loadCollections().catch((error) =>
         setAuthStatus(error instanceof Error ? error.message : "failed to load collections")
       );
+      loadUserCollections(user, session).catch((error) =>
+        setAuthStatus(error instanceof Error ? error.message : "failed to load your collections")
+      );
     }
     if (route.name === "collection") {
       setCollectionDetail(null);
@@ -146,6 +151,11 @@ export function useAppRouteEffects({
     if (route.name === "admin") {
       loadAdminCollections(session, user).catch((error) =>
         setAdminStatus(error instanceof Error ? error.message : "failed to load admin collections")
+      );
+    }
+    if (user) {
+      loadUserCollections(user, session).catch((error) =>
+        setAuthStatus(error instanceof Error ? error.message : "failed to load your collections")
       );
     }
   }, [route, user, session]);

--- a/src/app/useTheme.ts
+++ b/src/app/useTheme.ts
@@ -1,0 +1,24 @@
+import { useEffect, useState } from "react";
+
+export type AppTheme = "light" | "dark";
+
+const themeStorageKey = "codex-pets-theme";
+
+export function useTheme() {
+  const [theme, setTheme] = useState<AppTheme>(() => {
+    const stored = window.localStorage.getItem(themeStorageKey);
+    return stored === "dark" ? "dark" : "light";
+  });
+
+  useEffect(() => {
+    document.documentElement.dataset.theme = theme;
+    document.documentElement.style.colorScheme = theme;
+    window.localStorage.setItem(themeStorageKey, theme);
+  }, [theme]);
+
+  function toggleTheme() {
+    setTheme((current) => current === "dark" ? "light" : "dark");
+  }
+
+  return { theme, toggleTheme };
+}

--- a/src/collections/UserCollectionModals.tsx
+++ b/src/collections/UserCollectionModals.tsx
@@ -1,8 +1,10 @@
 import { type FormEvent } from "react";
+import { formatMetric } from "../domain/format";
 import type { CollectionSummary, Pet } from "../domain/types";
 import { CyclingPetPreview } from "../pets/PetPreview";
 import { Icon } from "../ui/Icon";
 import { Spinner } from "../ui/Spinner";
+import type { CollectionPetAdderState } from "./useUserCollections";
 
 type CollectionEditorState = {
   mode: "create" | "edit";
@@ -98,6 +100,7 @@ export function PetCollectorModal({
   onSubmit: (event: FormEvent) => void | Promise<void>;
   onClose: () => void;
 }) {
+  const requiresNewCollection = collections.length === 0;
   return (
     <div
       className="modalBackdrop"
@@ -106,11 +109,11 @@ export function PetCollectorModal({
         if (event.target === event.currentTarget && !busy) onClose();
       }}
     >
-      <section className="authModal userCollectionModal" role="dialog" aria-modal="true" aria-label={`Save ${pet.displayName} to collections`}>
+      <section className="authModal userCollectionModal" role="dialog" aria-modal="true" aria-label={`Add ${pet.displayName} to a collection`}>
         <div className="modalHeader">
           <div className="modalTitle compact">
-            <p className="metaText">Save pet</p>
-            <h2>{pet.displayName}</h2>
+            <p className="metaText">{pet.displayName}</p>
+            <h2>Add to collection</h2>
           </div>
           <button className="btn btnSm btnGhost modalCloseButton" type="button" onClick={onClose} disabled={busy}>
             <Icon name="close" size={12} />
@@ -137,19 +140,132 @@ export function PetCollectorModal({
             </div>
           ) : null}
           <label className="stackField">
-            <span className="fieldLabel">New collection</span>
+            <span className="fieldLabel">{requiresNewCollection ? "Collection name" : "New collection"}</span>
             <input
               value={newName}
               onChange={(event) => onNewName(event.target.value)}
-              placeholder="Optional"
+              placeholder={requiresNewCollection ? "Name a new collection" : "Optional"}
               maxLength={80}
+              autoFocus={requiresNewCollection}
             />
           </label>
           <button className="btn btnPrimary btnLg" type="submit" disabled={busy}>
             {busy ? <Spinner size={14} /> : <Icon name="package" size={14} />}
-            {busy ? "Saving" : "Save to collections"}
+            {busy ? "Saving" : requiresNewCollection ? "Create and add" : "Add to collection"}
           </button>
         </form>
+        {status && <p className="status" role="alert">{status}</p>}
+      </section>
+    </div>
+  );
+}
+
+export function CollectionPetAdderModal({
+  adder,
+  status,
+  loading,
+  busyPetId,
+  onQuery,
+  onSearch,
+  onAdd,
+  onClose
+}: {
+  adder: CollectionPetAdderState;
+  status: string;
+  loading: boolean;
+  busyPetId: string;
+  onQuery: (query: string) => void;
+  onSearch: (event: FormEvent) => void | Promise<void>;
+  onAdd: (pet: Pet) => void | Promise<void>;
+  onClose: () => void;
+}) {
+  const petIds = adder.collection.petIds || [];
+  const busy = loading || Boolean(busyPetId);
+  return (
+    <div
+      className="modalBackdrop"
+      role="presentation"
+      onClick={(event) => {
+        if (event.target === event.currentTarget && !busy) onClose();
+      }}
+    >
+      <section className="authModal userCollectionModal collectionPetAdderModal" role="dialog" aria-modal="true" aria-label={`Add pet to ${adder.collection.displayName}`}>
+        <div className="modalHeader">
+          <div className="modalTitle compact">
+            <p className="metaText">{adder.collection.displayName}</p>
+            <h2>Add pet</h2>
+          </div>
+          <button className="btn btnSm btnGhost modalCloseButton" type="button" onClick={onClose} disabled={busy}>
+            <Icon name="close" size={12} />
+            Close
+          </button>
+        </div>
+        <form className="petSwapSearchWrap collectionPetAdderSearch" onSubmit={onSearch}>
+          <span className="petSwapSearchPrefix" aria-hidden="true">›</span>
+          <input
+            type="search"
+            className="petSwapSearch"
+            placeholder="search all pets…"
+            value={adder.query}
+            onChange={(event) => onQuery(event.target.value)}
+            autoFocus
+            autoComplete="off"
+            spellCheck={false}
+          />
+          <button className="btn btnSm btnPrimary collectionPetAdderSearchButton" type="submit" disabled={loading}>
+            {loading ? <Spinner size={13} /> : <Icon name="search" size={13} />}
+            Search
+          </button>
+        </form>
+        <div className="petSwapMenuHeader collectionPetAdderResultsHeader">
+          <p className="petSwapMenuLabel">
+            <span className="petSwapMenuLabelDot" aria-hidden="true" />
+            Results
+          </p>
+          <span className="petSwapMenuCount">
+            {adder.searched ? `${formatMetric(adder.results.length)} / ${formatMetric(adder.total)}` : "Search pets"}
+          </span>
+        </div>
+        {!adder.searched && (
+          <div className="petSwapEmpty" role="status">
+            <span className="petSwapEmptyMark" aria-hidden="true">·_·</span>
+            <p>Search all pets, then pick one to add.</p>
+          </div>
+        )}
+        {adder.searched && adder.results.length === 0 && (
+          <div className="petSwapEmpty" role="status">
+            <span className="petSwapEmptyMark" aria-hidden="true">·_·</span>
+            <p>No matches.</p>
+          </div>
+        )}
+        {adder.results.length > 0 && (
+          <div className="petSwapGrid collectionPetAdderGrid">
+            {adder.results.map((pet) => {
+              const alreadyAdded = petIds.includes(pet.id);
+              const petBusy = busyPetId === pet.id;
+              return (
+                <button
+                  key={pet.id}
+                  type="button"
+                  className="petSwapTile"
+                  disabled={loading || Boolean(busyPetId) || alreadyAdded}
+                  data-active={alreadyAdded || undefined}
+                  aria-label={alreadyAdded ? `${pet.displayName} is already in this collection` : `Add ${pet.displayName}`}
+                  title={alreadyAdded ? "Already in collection" : pet.displayName}
+                  onClick={() => onAdd(pet)}
+                >
+                  <span className="petSwapTileFrame">
+                    <span
+                      className="petSwapTileSprite"
+                      style={{ backgroundImage: `url(${pet.spritesheetUrl})` }}
+                    />
+                  </span>
+                  <span className="petSwapTileName">{petBusy ? "Adding" : pet.displayName}</span>
+                </button>
+              );
+            })}
+          </div>
+        )}
         {status && <p className="status" role="alert">{status}</p>}
       </section>
     </div>

--- a/src/collections/UserCollectionModals.tsx
+++ b/src/collections/UserCollectionModals.tsx
@@ -1,0 +1,157 @@
+import { type FormEvent } from "react";
+import type { CollectionSummary, Pet } from "../domain/types";
+import { CyclingPetPreview } from "../pets/PetPreview";
+import { Icon } from "../ui/Icon";
+import { Spinner } from "../ui/Spinner";
+
+type CollectionEditorState = {
+  mode: "create" | "edit";
+  collection: CollectionSummary | null;
+  displayName: string;
+};
+
+export function UserCollectionEditorModal({
+  editor,
+  status,
+  busy,
+  onDisplayName,
+  onSubmit,
+  onClose
+}: {
+  editor: CollectionEditorState;
+  status: string;
+  busy: boolean;
+  onDisplayName: (displayName: string) => void;
+  onSubmit: (event: FormEvent) => void | Promise<void>;
+  onClose: () => void;
+}) {
+  const title = editor.mode === "create" ? "New collection" : editor.collection?.displayName || "Edit collection";
+  return (
+    <div
+      className="modalBackdrop"
+      role="presentation"
+      onClick={(event) => {
+        if (event.target === event.currentTarget && !busy) onClose();
+      }}
+    >
+      <section className="authModal userCollectionModal" role="dialog" aria-modal="true" aria-label={title}>
+        <div className="modalHeader">
+          <div className="modalTitle compact">
+            <p className="metaText">Collection</p>
+            <h2>{title}</h2>
+          </div>
+          <button className="btn btnSm btnGhost modalCloseButton" type="button" onClick={onClose} disabled={busy}>
+            <Icon name="close" size={12} />
+            Close
+          </button>
+        </div>
+        <form className="stackForm" onSubmit={onSubmit}>
+          <label className="stackField">
+            <span className="fieldLabel">Name</span>
+            <input
+              value={editor.displayName}
+              onChange={(event) => onDisplayName(event.target.value)}
+              maxLength={80}
+              autoFocus
+            />
+          </label>
+          {editor.collection?.topPets.length ? (
+            <div className="userCollectionPreviewStrip" aria-label="Collection preview">
+              {editor.collection.topPets.map((pet) => (
+                <span className="userCollectionPreviewSlot" key={pet.id}>
+                  <CyclingPetPreview pet={pet} size="thumb" transparent />
+                </span>
+              ))}
+            </div>
+          ) : null}
+          <button className="btn btnPrimary btnLg" type="submit" disabled={busy}>
+            {busy ? <Spinner size={14} /> : <Icon name="check" size={14} />}
+            {busy ? "Saving" : editor.mode === "create" ? "Create collection" : "Save collection"}
+          </button>
+        </form>
+        {status && <p className="status" role="alert">{status}</p>}
+      </section>
+    </div>
+  );
+}
+
+export function PetCollectorModal({
+  pet,
+  collections,
+  selectedSlugs,
+  newName,
+  status,
+  busy,
+  onToggle,
+  onNewName,
+  onSubmit,
+  onClose
+}: {
+  pet: Pet;
+  collections: CollectionSummary[];
+  selectedSlugs: string[];
+  newName: string;
+  status: string;
+  busy: boolean;
+  onToggle: (slug: string) => void;
+  onNewName: (name: string) => void;
+  onSubmit: (event: FormEvent) => void | Promise<void>;
+  onClose: () => void;
+}) {
+  return (
+    <div
+      className="modalBackdrop"
+      role="presentation"
+      onClick={(event) => {
+        if (event.target === event.currentTarget && !busy) onClose();
+      }}
+    >
+      <section className="authModal userCollectionModal" role="dialog" aria-modal="true" aria-label={`Save ${pet.displayName} to collections`}>
+        <div className="modalHeader">
+          <div className="modalTitle compact">
+            <p className="metaText">Save pet</p>
+            <h2>{pet.displayName}</h2>
+          </div>
+          <button className="btn btnSm btnGhost modalCloseButton" type="button" onClick={onClose} disabled={busy}>
+            <Icon name="close" size={12} />
+            Close
+          </button>
+        </div>
+        <form className="stackForm" onSubmit={onSubmit}>
+          {collections.length ? (
+            <div className="collectionCheckboxList">
+              {collections.map((collection) => (
+                <label className="collectionCheckbox" key={collection.slug}>
+                  <input
+                    type="checkbox"
+                    checked={selectedSlugs.includes(collection.slug)}
+                    disabled={busy}
+                    onChange={() => onToggle(collection.slug)}
+                  />
+                  <span>
+                    <strong>{collection.displayName}</strong>
+                    <small>{collection.petCount} {collection.petCount === 1 ? "pet" : "pets"}</small>
+                  </span>
+                </label>
+              ))}
+            </div>
+          ) : null}
+          <label className="stackField">
+            <span className="fieldLabel">New collection</span>
+            <input
+              value={newName}
+              onChange={(event) => onNewName(event.target.value)}
+              placeholder="Optional"
+              maxLength={80}
+            />
+          </label>
+          <button className="btn btnPrimary btnLg" type="submit" disabled={busy}>
+            {busy ? <Spinner size={14} /> : <Icon name="package" size={14} />}
+            {busy ? "Saving" : "Save to collections"}
+          </button>
+        </form>
+        {status && <p className="status" role="alert">{status}</p>}
+      </section>
+    </div>
+  );
+}

--- a/src/collections/useUserCollections.ts
+++ b/src/collections/useUserCollections.ts
@@ -2,7 +2,7 @@ import { useState, type Dispatch, type FormEvent, type SetStateAction } from "re
 import { readJson } from "../domain/http";
 import { normalizePet } from "../domain/pets";
 import { navigate } from "../domain/routing";
-import type { AuthSession, CollectionSummary, ContentMode, Pet, Route, User } from "../domain/types";
+import type { AuthSession, CollectionSummary, ContentMode, GalleryResponse, Pet, Route, User } from "../domain/types";
 
 type ApiFetch = (path: string, init?: RequestInit, authSession?: AuthSession | null) => Promise<Response>;
 
@@ -10,6 +10,14 @@ type CollectionEditorState = {
   mode: "create" | "edit";
   collection: CollectionSummary | null;
   displayName: string;
+};
+
+export type CollectionPetAdderState = {
+  collection: Omit<CollectionSummary, "topPets">;
+  query: string;
+  results: Pet[];
+  total: number;
+  searched: boolean;
 };
 
 export function useUserCollections({
@@ -47,6 +55,10 @@ export function useUserCollections({
   const [collectNewName, setCollectNewName] = useState("");
   const [collectStatus, setCollectStatus] = useState("");
   const [collectBusy, setCollectBusy] = useState(false);
+  const [collectionPetAdder, setCollectionPetAdder] = useState<CollectionPetAdderState | null>(null);
+  const [collectionPetAdderStatus, setCollectionPetAdderStatus] = useState("");
+  const [collectionPetAdderLoading, setCollectionPetAdderLoading] = useState(false);
+  const [collectionPetAdderBusyId, setCollectionPetAdderBusyId] = useState("");
 
   function openCollectionCreator() {
     if (!user) {
@@ -147,6 +159,11 @@ export function useUserCollections({
   async function submitPetCollector(event: FormEvent) {
     event.preventDefault();
     if (!collectPet || collectBusy || !user) return;
+    const newCollectionName = collectNewName.trim();
+    if (!userCollections.length && !newCollectionName) {
+      setCollectStatus("Name a collection to add this pet.");
+      return;
+    }
     setCollectBusy(true);
     setCollectStatus("");
     try {
@@ -163,11 +180,11 @@ export function useUserCollections({
           body: JSON.stringify({ petIds: nextPetIds })
         }, session));
       }
-      if (collectNewName.trim()) {
+      if (newCollectionName) {
         await readJson<{ collection: CollectionSummary }>(await apiFetch("/api/collections", {
           method: "POST",
           headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({ displayName: collectNewName.trim(), petIds: [collectPet.id] })
+          body: JSON.stringify({ displayName: newCollectionName, petIds: [collectPet.id] })
         }, session));
       }
       await loadUserCollections(user, session, contentMode);
@@ -182,6 +199,97 @@ export function useUserCollections({
       setCollectStatus(error instanceof Error ? error.message : "Could not save collections.");
     } finally {
       setCollectBusy(false);
+    }
+  }
+
+  function openCollectionPetAdder(collection: Omit<CollectionSummary, "topPets">) {
+    if (!user) {
+      openAuth();
+      return;
+    }
+    setCollectionPetAdder({
+      collection,
+      query: "",
+      results: [],
+      total: 0,
+      searched: false
+    });
+    setCollectionPetAdderStatus("");
+    setCollectionPetAdderLoading(false);
+    setCollectionPetAdderBusyId("");
+  }
+
+  function closeCollectionPetAdder() {
+    if (collectionPetAdderLoading || collectionPetAdderBusyId) return;
+    setCollectionPetAdder(null);
+    setCollectionPetAdderStatus("");
+  }
+
+  function setCollectionPetAdderQuery(query: string) {
+    setCollectionPetAdder((current) => current ? { ...current, query } : current);
+  }
+
+  async function searchCollectionPetAdder(event: FormEvent) {
+    event.preventDefault();
+    if (!collectionPetAdder || collectionPetAdderLoading) return;
+    setCollectionPetAdderLoading(true);
+    setCollectionPetAdderStatus("");
+    try {
+      const params = new URLSearchParams();
+      params.set("page", "1");
+      params.set("pageSize", "60");
+      const query = collectionPetAdder.query.trim();
+      if (query) {
+        params.set("q", query);
+      }
+      if (contentMode === "all") {
+        params.set("content", "all");
+      }
+      const body = await readJson<GalleryResponse>(await apiFetch(`/api/pets?${params}`, {}, session));
+      setCollectionPetAdder((current) => current ? {
+        ...current,
+        results: body.pets.map(normalizePet),
+        total: body.total,
+        searched: true
+      } : current);
+    } catch (error) {
+      setCollectionPetAdderStatus(error instanceof Error ? error.message : "Could not search pets.");
+    } finally {
+      setCollectionPetAdderLoading(false);
+    }
+  }
+
+  async function addPetToCollection(pet: Pet) {
+    if (!collectionPetAdder || !user || collectionPetAdderBusyId) return;
+    const petIds = collectionPetAdder.collection.petIds;
+    if (!petIds) {
+      setCollectionPetAdderStatus("Collection data is not ready.");
+      return;
+    }
+    if (petIds.includes(pet.id)) return;
+    setCollectionPetAdderBusyId(pet.id);
+    setCollectionPetAdderStatus("");
+    try {
+      const body = await readJson<{ collection: CollectionSummary }>(await apiFetch(`/api/collections/${collectionPetAdder.collection.slug}`, {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ petIds: [...petIds, pet.id] })
+      }, session));
+      const collection = normalizeCollection(body.collection);
+      replaceUserCollection(collection);
+      setCollectionDetail(collection);
+      setCollectionPetAdder((current) => current ? { ...current, collection } : current);
+      await Promise.all([
+        loadUserCollections(user, session, contentMode),
+        route.name === "collection" && route.slug === collection.slug
+          ? loadCollectionDetail(route.slug, session, contentMode)
+          : Promise.resolve()
+      ]);
+      setCollectionPetAdderStatus(`Added ${pet.displayName}.`);
+    } catch (error) {
+      setCollectionPetAdderStatus(error instanceof Error ? error.message : "Could not add pet.");
+    } finally {
+      setCollectionPetAdderBusyId("");
     }
   }
 
@@ -255,6 +363,15 @@ export function useUserCollections({
     closePetCollector,
     toggleCollectSlug,
     submitPetCollector,
+    collectionPetAdder,
+    collectionPetAdderStatus,
+    collectionPetAdderLoading,
+    collectionPetAdderBusyId,
+    setCollectionPetAdderQuery,
+    openCollectionPetAdder,
+    closeCollectionPetAdder,
+    searchCollectionPetAdder,
+    addPetToCollection,
     removePetFromCollection,
     deleteUserCollection,
     startCollectionRoom

--- a/src/collections/useUserCollections.ts
+++ b/src/collections/useUserCollections.ts
@@ -1,0 +1,269 @@
+import { useState, type Dispatch, type FormEvent, type SetStateAction } from "react";
+import { readJson } from "../domain/http";
+import { normalizePet } from "../domain/pets";
+import { navigate } from "../domain/routing";
+import type { AuthSession, CollectionSummary, ContentMode, Pet, Route, User } from "../domain/types";
+
+type ApiFetch = (path: string, init?: RequestInit, authSession?: AuthSession | null) => Promise<Response>;
+
+type CollectionEditorState = {
+  mode: "create" | "edit";
+  collection: CollectionSummary | null;
+  displayName: string;
+};
+
+export function useUserCollections({
+  user,
+  session,
+  route,
+  contentMode,
+  apiFetch,
+  userCollections,
+  setUserCollections,
+  setCollectionDetail,
+  setCollectionPets,
+  loadUserCollections,
+  loadCollectionDetail,
+  openAuth
+}: {
+  user: User | null;
+  session: AuthSession | null;
+  route: Route;
+  contentMode: ContentMode;
+  apiFetch: ApiFetch;
+  userCollections: CollectionSummary[];
+  setUserCollections: Dispatch<SetStateAction<CollectionSummary[]>>;
+  setCollectionDetail: Dispatch<SetStateAction<Omit<CollectionSummary, "topPets"> | null>>;
+  setCollectionPets: Dispatch<SetStateAction<Pet[]>>;
+  loadUserCollections: (currentUser?: User | null, authSession?: AuthSession | null, content?: ContentMode) => Promise<void>;
+  loadCollectionDetail: (slug: string, authSession?: AuthSession | null, content?: ContentMode) => Promise<void>;
+  openAuth: () => void;
+}) {
+  const [collectionEditor, setCollectionEditor] = useState<CollectionEditorState | null>(null);
+  const [collectionEditorStatus, setCollectionEditorStatus] = useState("");
+  const [collectionEditorBusy, setCollectionEditorBusy] = useState(false);
+  const [collectPet, setCollectPet] = useState<Pet | null>(null);
+  const [collectSelectedSlugs, setCollectSelectedSlugs] = useState<string[]>([]);
+  const [collectNewName, setCollectNewName] = useState("");
+  const [collectStatus, setCollectStatus] = useState("");
+  const [collectBusy, setCollectBusy] = useState(false);
+
+  function openCollectionCreator() {
+    if (!user) {
+      openAuth();
+      return;
+    }
+    setCollectionEditor({ mode: "create", collection: null, displayName: "" });
+    setCollectionEditorStatus("");
+    setCollectionEditorBusy(false);
+  }
+
+  function openCollectionEditor(collection: CollectionSummary) {
+    setCollectionEditor({ mode: "edit", collection, displayName: collection.displayName });
+    setCollectionEditorStatus("");
+    setCollectionEditorBusy(false);
+  }
+
+  function closeCollectionEditor() {
+    if (collectionEditorBusy) return;
+    setCollectionEditor(null);
+    setCollectionEditorStatus("");
+  }
+
+  async function submitCollectionEditor(event: FormEvent) {
+    event.preventDefault();
+    if (!collectionEditor || collectionEditorBusy || !user) return;
+    const displayName = collectionEditor.displayName.trim();
+    if (!displayName) {
+      setCollectionEditorStatus("Name the collection.");
+      return;
+    }
+    setCollectionEditorBusy(true);
+    setCollectionEditorStatus("");
+    try {
+      if (collectionEditor.mode === "create") {
+        const body = await readJson<{ collection: CollectionSummary }>(await apiFetch("/api/collections", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ displayName, petIds: [] })
+        }, session));
+        const collection = normalizeCollection(body.collection);
+        setUserCollections((current) => [collection, ...current]);
+        setCollectionEditor(null);
+        navigate(`#/collections/${collection.slug}`);
+      } else if (collectionEditor.collection) {
+        const petIds = collectionEditor.collection.petIds || [];
+        const body = await readJson<{ collection: CollectionSummary }>(await apiFetch(`/api/collections/${collectionEditor.collection.slug}`, {
+          method: "PATCH",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ displayName, petIds })
+        }, session));
+        const collection = normalizeCollection(body.collection);
+        replaceUserCollection(collection);
+        if (route.name === "collection" && route.slug === collection.slug) {
+          setCollectionDetail(collection);
+        }
+        setCollectionEditor(null);
+      }
+    } catch (error) {
+      setCollectionEditorStatus(error instanceof Error ? error.message : "Could not save collection.");
+    } finally {
+      setCollectionEditorBusy(false);
+    }
+  }
+
+  function setCollectionEditorDisplayName(displayName: string) {
+    setCollectionEditor((current) => current ? { ...current, displayName } : current);
+  }
+
+  function openPetCollector(pet: Pet) {
+    if (!user) {
+      openAuth();
+      return;
+    }
+    setCollectPet(pet);
+    setCollectSelectedSlugs(userCollections
+      .filter((collection) => collection.petIds?.includes(pet.id))
+      .map((collection) => collection.slug));
+    setCollectNewName("");
+    setCollectStatus("");
+    setCollectBusy(false);
+  }
+
+  function closePetCollector() {
+    if (collectBusy) return;
+    setCollectPet(null);
+    setCollectSelectedSlugs([]);
+    setCollectNewName("");
+    setCollectStatus("");
+  }
+
+  function toggleCollectSlug(slug: string) {
+    setCollectSelectedSlugs((current) =>
+      current.includes(slug) ? current.filter((item) => item !== slug) : [...current, slug]
+    );
+  }
+
+  async function submitPetCollector(event: FormEvent) {
+    event.preventDefault();
+    if (!collectPet || collectBusy || !user) return;
+    setCollectBusy(true);
+    setCollectStatus("");
+    try {
+      const selected = new Set(collectSelectedSlugs);
+      for (const collection of userCollections) {
+        const petIds = collection.petIds || [];
+        const hasPet = petIds.includes(collectPet.id);
+        const shouldHavePet = selected.has(collection.slug);
+        if (hasPet === shouldHavePet) continue;
+        const nextPetIds = shouldHavePet ? [...petIds, collectPet.id] : petIds.filter((petId) => petId !== collectPet.id);
+        await readJson<{ collection: CollectionSummary }>(await apiFetch(`/api/collections/${collection.slug}`, {
+          method: "PATCH",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ petIds: nextPetIds })
+        }, session));
+      }
+      if (collectNewName.trim()) {
+        await readJson<{ collection: CollectionSummary }>(await apiFetch("/api/collections", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ displayName: collectNewName.trim(), petIds: [collectPet.id] })
+        }, session));
+      }
+      await loadUserCollections(user, session, contentMode);
+      if (route.name === "collection") {
+        await loadCollectionDetail(route.slug, session, contentMode);
+      }
+      setCollectPet(null);
+      setCollectSelectedSlugs([]);
+      setCollectNewName("");
+      setCollectStatus("");
+    } catch (error) {
+      setCollectStatus(error instanceof Error ? error.message : "Could not save collections.");
+    } finally {
+      setCollectBusy(false);
+    }
+  }
+
+  async function removePetFromCollection(collection: Omit<CollectionSummary, "topPets">, pet: Pet) {
+    if (!user) return;
+    if (!collection.petIds) return;
+    const petIds = collection.petIds.filter((petId) => petId !== pet.id);
+    const body = await readJson<{ collection: CollectionSummary }>(await apiFetch(`/api/collections/${collection.slug}`, {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ petIds })
+    }, session));
+    const next = normalizeCollection(body.collection);
+    replaceUserCollection(next);
+    if (route.name === "collection" && route.slug === collection.slug) {
+      setCollectionDetail(next);
+      setCollectionPets((current) => current.filter((item) => item.id !== pet.id));
+    }
+  }
+
+  async function deleteUserCollection(collection: CollectionSummary) {
+    if (!user) return;
+    const confirmed = window.confirm(`Delete ${collection.displayName}?`);
+    if (!confirmed) return;
+    await readJson<{ ok: true }>(await apiFetch(`/api/collections/${collection.slug}`, { method: "DELETE" }, session));
+    setUserCollections((current) => current.filter((item) => item.slug !== collection.slug));
+    if (route.name === "collection" && route.slug === collection.slug) {
+      navigate("#/collections");
+    }
+  }
+
+  async function startCollectionRoom(collection: Omit<CollectionSummary, "topPets"> & { topPets?: CollectionSummary["topPets"] }, petId?: string) {
+    if (!user) {
+      openAuth();
+      return;
+    }
+    const hostPetId = petId || collection.petIds?.[0] || collection.topPets?.[0]?.id;
+    if (!hostPetId) return;
+    const body = await readJson<{ id: string }>(await apiFetch("/api/rooms", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        pet_id: hostPetId,
+        display_name: collection.displayName,
+        collection_slug: collection.slug
+      })
+    }, session));
+    navigate(`#/rooms/${body.id}`);
+  }
+
+  function replaceUserCollection(collection: CollectionSummary) {
+    setUserCollections((current) => current.map((item) => item.slug === collection.slug ? collection : item));
+  }
+
+  return {
+    collectionEditor,
+    collectionEditorStatus,
+    collectionEditorBusy,
+    setCollectionEditorDisplayName,
+    openCollectionCreator,
+    openCollectionEditor,
+    closeCollectionEditor,
+    submitCollectionEditor,
+    collectPet,
+    collectSelectedSlugs,
+    collectNewName,
+    collectStatus,
+    collectBusy,
+    setCollectNewName,
+    openPetCollector,
+    closePetCollector,
+    toggleCollectSlug,
+    submitPetCollector,
+    removePetFromCollection,
+    deleteUserCollection,
+    startCollectionRoom
+  };
+}
+
+function normalizeCollection(collection: CollectionSummary): CollectionSummary {
+  return {
+    ...collection,
+    topPets: collection.topPets.map(normalizePet)
+  };
+}

--- a/src/collections/user-collections.css
+++ b/src/collections/user-collections.css
@@ -97,6 +97,100 @@
   overflow: auto;
 }
 
+.collectionPetAdderModal {
+  width: min(760px, calc(100vw - 32px));
+}
+
+.collectionPetAdderSearch {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  gap: 8px;
+  margin-bottom: 12px;
+}
+
+.collectionPetAdderSearch .petSwapSearchPrefix {
+  left: 12px;
+}
+
+.collectionPetAdderSearchButton {
+  min-height: 36px;
+}
+
+.collectionPetAdderResultsHeader {
+  margin-top: 0;
+}
+
+.collectionPetAdderGrid {
+  grid-template-columns: repeat(auto-fill, minmax(62px, 1fr));
+  max-height: min(420px, 48vh);
+  overflow: auto;
+  padding-right: 4px;
+  scrollbar-width: thin;
+  scrollbar-color: color-mix(in srgb, var(--accent) 35%, transparent) transparent;
+}
+
+.collectionPetAdderGrid::-webkit-scrollbar {
+  width: 6px;
+}
+
+.collectionPetAdderGrid::-webkit-scrollbar-track {
+  background: transparent;
+}
+
+.collectionPetAdderGrid::-webkit-scrollbar-thumb {
+  background: color-mix(in srgb, var(--accent) 28%, transparent);
+  border-radius: 3px;
+}
+
+.collectionPetAdderModal .petSwapTile {
+  background: var(--surface-soft);
+  border-color: var(--border);
+  color: var(--foreground);
+}
+
+.collectionPetAdderModal .petSwapTile:hover:not(:disabled),
+.collectionPetAdderModal .petSwapTile:focus-visible:not(:disabled) {
+  background: color-mix(in srgb, var(--accent-soft) 52%, var(--surface));
+  border-color: var(--accent-deep);
+}
+
+.collectionPetAdderModal .petSwapTileFrame {
+  background:
+    radial-gradient(60% 22% at 50% 92%, var(--preview-ground), transparent 70%),
+    radial-gradient(120% 90% at 50% 0%, var(--inset-highlight), transparent 60%);
+}
+
+.collectionPetAdderModal .petSwapTileName {
+  color: var(--muted);
+}
+
+.collectionPetAdderModal .petSwapTile[data-active] {
+  background: color-mix(in srgb, var(--accent-soft) 70%, var(--surface-soft));
+  border-color: var(--accent-deep);
+}
+
+.collectionPetAdderModal .petSwapTile[data-active] .petSwapTileName {
+  color: var(--accent-deep);
+}
+
+.collectionPetAdderModal .petSwapMenuHeader {
+  border-bottom-color: var(--border);
+}
+
+.collectionPetAdderModal .petSwapMenuCount {
+  color: var(--muted);
+  border-color: var(--border);
+  background: var(--surface-soft);
+}
+
+.collectionPetAdderModal .petSwapEmpty {
+  color: var(--muted);
+}
+
+.collectionPetAdderModal .petSwapEmptyMark {
+  color: var(--accent-deep);
+}
+
 .userCollectionPreviewStrip {
   display: flex;
   gap: 8px;
@@ -131,5 +225,9 @@
 
   .userCollectionsActions {
     justify-content: flex-start;
+  }
+
+  .collectionPetAdderSearch {
+    grid-template-columns: 1fr;
   }
 }

--- a/src/collections/user-collections.css
+++ b/src/collections/user-collections.css
@@ -1,0 +1,135 @@
+.userCollectionsBand {
+  margin-bottom: 28px;
+  padding-bottom: 26px;
+  border-bottom: 1px dashed var(--border);
+}
+
+.userCollectionsHeader {
+  display: flex;
+  justify-content: space-between;
+  gap: 18px;
+  align-items: flex-end;
+  margin-bottom: 16px;
+}
+
+.userCollectionsHeader h2 {
+  margin: 0;
+  font-size: clamp(1.35rem, 3vw, 2rem);
+  line-height: 1;
+}
+
+.userCollectionsActions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  justify-content: flex-end;
+}
+
+.userCollectionsGrid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(220px, 1fr));
+  gap: 14px;
+}
+
+.userCollectionCard {
+  display: flex;
+  flex-direction: column;
+  min-height: 220px;
+  padding: 14px;
+  gap: 12px;
+}
+
+.userCollectionCardHeader {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: 10px;
+}
+
+.userCollectionCardTitle {
+  margin: 0;
+  font-size: 1.05rem;
+  line-height: 1.1;
+}
+
+.userCollectionCardMeta {
+  margin: 4px 0 0;
+  color: var(--muted);
+  font-family: var(--font-mono);
+  font-size: 0.76rem;
+  letter-spacing: 0;
+  text-transform: uppercase;
+}
+
+.userCollectionPreview {
+  display: flex;
+  align-items: flex-end;
+  min-height: 92px;
+  padding: 10px;
+  border: 1px solid var(--border-soft);
+  border-radius: var(--radius-md);
+  background: var(--surface-soft);
+  overflow: hidden;
+}
+
+.userCollectionPreview .collectionPreviewStack {
+  width: 100%;
+}
+
+.userCollectionEmptyPreview {
+  width: 100%;
+  color: var(--muted);
+  font-family: var(--font-mono);
+  font-size: 0.78rem;
+  text-align: center;
+  text-transform: uppercase;
+}
+
+.userCollectionCardActions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  margin-top: auto;
+}
+
+.userCollectionModal .collectionCheckboxList {
+  max-height: min(320px, 45vh);
+  overflow: auto;
+}
+
+.userCollectionPreviewStrip {
+  display: flex;
+  gap: 8px;
+  padding: 10px;
+  border: 1px solid var(--border-soft);
+  border-radius: var(--radius-md);
+  background: var(--surface-soft);
+  overflow: hidden;
+}
+
+.userCollectionPreviewSlot {
+  width: 52px;
+  height: 58px;
+  display: grid;
+  place-items: end center;
+  flex: 0 0 auto;
+}
+
+.collectionOwnerLine {
+  color: var(--muted);
+  font-family: var(--font-mono);
+  font-size: 0.8rem;
+  letter-spacing: 0;
+  text-transform: uppercase;
+}
+
+@media (max-width: 720px) {
+  .userCollectionsHeader {
+    align-items: stretch;
+    flex-direction: column;
+  }
+
+  .userCollectionsActions {
+    justify-content: flex-start;
+  }
+}

--- a/src/domain/types.ts
+++ b/src/domain/types.ts
@@ -119,8 +119,11 @@ export type CreatorsLeaderboardResponse = {
 export type CollectionSummary = {
   slug: string;
   displayName: string;
+  ownerId: string | null;
+  editable?: boolean;
   petCount: number;
   topPets: Array<Pet>;
+  petIds?: Array<string>;
 };
 
 export type CollectionDetailResponse = {

--- a/src/gallery/CollectionPages.tsx
+++ b/src/gallery/CollectionPages.tsx
@@ -357,6 +357,7 @@ function CollectionDetailPage({
   onEditTags,
   onManageCollections,
   onCollect,
+  onAddPet,
   onRemoveFromUserCollection,
   onStartRoom,
   onToggleNsfw,
@@ -387,6 +388,7 @@ function CollectionDetailPage({
   onEditTags: (pet: Pet) => void;
   onManageCollections: (pet: Pet) => void;
   onCollect?: (pet: Pet) => void;
+  onAddPet?: (collection: Omit<CollectionSummary, "topPets">) => void;
   onRemoveFromUserCollection?: (pet: Pet) => void;
   onStartRoom?: () => void;
   onToggleNsfw: (pet: Pet) => void;
@@ -440,6 +442,12 @@ function CollectionDetailPage({
               </button>
             </section>
             <div className="collectionHeaderButtons">
+              {collection.editable && onAddPet && (
+                <button className="btn btnSm" type="button" onClick={() => onAddPet(collection)} aria-label={`Add pet to ${collection.displayName}`}>
+                  <Icon name="package" size={13} />
+                  Add pet
+                </button>
+              )}
               <button className="btn btnSm btnGhost" type="button" onClick={onShareCollection} aria-label={`Share ${collection.displayName}`}>
                 <Icon name="share" size={13} />
                 Share
@@ -496,17 +504,12 @@ function CollectionDetailPage({
                 onEditTags={onEditTags}
                 onManageCollections={onManageCollections}
                 onCollect={onCollect}
+                onRemoveFromCollection={onRemoveFromUserCollection}
                 onToggleNsfw={onToggleNsfw}
                 onShadowbanOwner={onShadowbanOwner}
                 onDelete={onDelete}
                 onSignIn={onSignIn}
               />
-              {onRemoveFromUserCollection && (
-                <button className="btn btnSm btnGhost" type="button" onClick={() => onRemoveFromUserCollection(pet)}>
-                  <Icon name="trash" size={13} />
-                  Remove from collection
-                </button>
-              )}
             </div>
           ))}
         </div>

--- a/src/gallery/CollectionPages.tsx
+++ b/src/gallery/CollectionPages.tsx
@@ -36,16 +36,30 @@ export function CollectionDetailPageWithPresence({
 // every other page.
 export function CollectionsPageWithPresence({
   collections,
+  userCollections,
   loading,
+  userCollectionsLoading,
   signedIn,
   session,
+  onCreateCollection,
+  onEditCollection,
+  onDeleteCollection,
+  onStartUserCollectionRoom,
+  onShareCollection,
   onShareRoom,
   onSignIn
 }: {
   collections: Array<CollectionSummary>;
+  userCollections: Array<CollectionSummary>;
   loading: boolean;
+  userCollectionsLoading: boolean;
   signedIn: boolean;
   session: AuthSession | null;
+  onCreateCollection: () => void;
+  onEditCollection: (collection: CollectionSummary) => void;
+  onDeleteCollection: (collection: CollectionSummary) => void;
+  onStartUserCollectionRoom: (collection: CollectionSummary) => void;
+  onShareCollection: (collection: CollectionSummary) => void;
   onShareRoom: (collection: CollectionSummary) => void;
   onSignIn: () => void;
 }) {
@@ -54,9 +68,16 @@ export function CollectionsPageWithPresence({
   return (
     <CollectionsPage
       collections={collections}
+      userCollections={userCollections}
       loading={loading}
+      userCollectionsLoading={userCollectionsLoading}
       signedIn={signedIn}
       presenceCounts={presenceCounts}
+      onCreateCollection={onCreateCollection}
+      onEditCollection={onEditCollection}
+      onDeleteCollection={onDeleteCollection}
+      onStartUserCollectionRoom={onStartUserCollectionRoom}
+      onShareCollection={onShareCollection}
       onShareRoom={onShareRoom}
       onSignIn={onSignIn}
     />
@@ -65,14 +86,23 @@ export function CollectionsPageWithPresence({
 
 function CollectionsPage({
   collections,
+  userCollections,
   loading,
+  userCollectionsLoading,
   signedIn,
   presenceCounts,
+  onCreateCollection,
+  onEditCollection,
+  onDeleteCollection,
+  onStartUserCollectionRoom,
+  onShareCollection,
   onShareRoom,
   onSignIn
 }: {
   collections: Array<CollectionSummary>;
+  userCollections: Array<CollectionSummary>;
   loading: boolean;
+  userCollectionsLoading: boolean;
   signedIn: boolean;
   // One-shot snapshot of "people in the room" per slug at page-load
   // time. Empty when the user is signed out (private:true topics need
@@ -82,6 +112,11 @@ function CollectionsPage({
   // doubles as a way to find the collection itself, so a separate
   // collection-share action would just clutter the footer. Collection-
   // page share remains accessible from the detail page header.
+  onCreateCollection: () => void;
+  onEditCollection: (collection: CollectionSummary) => void;
+  onDeleteCollection: (collection: CollectionSummary) => void;
+  onStartUserCollectionRoom: (collection: CollectionSummary) => void;
+  onShareCollection: (collection: CollectionSummary) => void;
   onShareRoom: (collection: CollectionSummary) => void;
   onSignIn: () => void;
 }) {
@@ -94,6 +129,17 @@ function CollectionsPage({
           <p className="sectionSubhead">Curated packs you can browse, share, or jump into a permanent playground room with.</p>
         </div>
       </header>
+      <UserCollectionsSection
+        collections={userCollections}
+        loading={userCollectionsLoading}
+        signedIn={signedIn}
+        onCreate={onCreateCollection}
+        onEdit={onEditCollection}
+        onDelete={onDeleteCollection}
+        onStartRoom={onStartUserCollectionRoom}
+        onShare={onShareCollection}
+        onSignIn={onSignIn}
+      />
       {loading ? (
         <GallerySkeleton />
       ) : collections.length ? (
@@ -186,6 +232,110 @@ function CollectionsPage({
   );
 }
 
+function UserCollectionsSection({
+  collections,
+  loading,
+  signedIn,
+  onCreate,
+  onEdit,
+  onDelete,
+  onStartRoom,
+  onShare,
+  onSignIn
+}: {
+  collections: CollectionSummary[];
+  loading: boolean;
+  signedIn: boolean;
+  onCreate: () => void;
+  onEdit: (collection: CollectionSummary) => void;
+  onDelete: (collection: CollectionSummary) => void;
+  onStartRoom: (collection: CollectionSummary) => void;
+  onShare: (collection: CollectionSummary) => void;
+  onSignIn: () => void;
+}) {
+  return (
+    <section className="userCollectionsBand" aria-label="Your collections">
+      <header className="userCollectionsHeader">
+        <div>
+          <p className="metaText">Your collections</p>
+          <h2>Custom packs</h2>
+          <p className="sectionSubhead">Private to manage, public to share.</p>
+        </div>
+        <div className="userCollectionsActions">
+          {signedIn ? (
+            <button className="btn btnPrimary" type="button" onClick={onCreate}>
+              <Icon name="package" size={13} />
+              New collection
+            </button>
+          ) : (
+            <button className="btn btnPrimary" type="button" onClick={onSignIn}>
+              <Icon name="user" size={13} />
+              Sign in
+            </button>
+          )}
+        </div>
+      </header>
+      {!signedIn ? null : loading ? (
+        <GallerySkeleton />
+      ) : collections.length ? (
+        <div className="userCollectionsGrid">
+          {collections.map((collection) => (
+            <article className="userCollectionCard card" key={collection.slug}>
+              <div className="userCollectionCardHeader">
+                <div>
+                  <h3 className="userCollectionCardTitle">{collection.displayName}</h3>
+                  <p className="userCollectionCardMeta">
+                    {formatMetric(collection.petCount)} {collection.petCount === 1 ? "pet" : "pets"}
+                  </p>
+                </div>
+                <button className="btn btnSm btnGhost" type="button" onClick={() => onEdit(collection)} aria-label={`Edit ${collection.displayName}`}>
+                  <Icon name="sheet" size={13} />
+                </button>
+              </div>
+              <a className="userCollectionPreview" href={`#/collections/${collection.slug}`} aria-label={`Open ${collection.displayName}`}>
+                {collection.topPets.length ? (
+                  <div className="collectionPreviewStack">
+                    {collection.topPets.map((pet) => (
+                      <CyclingPetPreview key={pet.id} pet={pet} size="thumb" transparent />
+                    ))}
+                  </div>
+                ) : (
+                  <span className="userCollectionEmptyPreview">empty</span>
+                )}
+              </a>
+              <div className="userCollectionCardActions">
+                <a className="btn btnSm" href={`#/collections/${collection.slug}`}>
+                  <Icon name="eye" size={13} />
+                  Open
+                </a>
+                <button className="btn btnSm" type="button" onClick={() => onShare(collection)}>
+                  <Icon name="share" size={13} />
+                  Share
+                </button>
+                <button
+                  className="btn btnSm btnPrimary"
+                  type="button"
+                  disabled={collection.petCount === 0}
+                  onClick={() => onStartRoom(collection)}
+                >
+                  <Icon name="play" size={11} />
+                  Room
+                </button>
+                <button className="btn btnSm btnDanger" type="button" onClick={() => onDelete(collection)}>
+                  <Icon name="trash" size={13} />
+                  Delete
+                </button>
+              </div>
+            </article>
+          ))}
+        </div>
+      ) : (
+        <EmptyState text="No custom collections yet." />
+      )}
+    </section>
+  );
+}
+
 function CollectionDetailPage({
   collection,
   pets,
@@ -206,6 +356,9 @@ function CollectionDetailPage({
   onTagClick,
   onEditTags,
   onManageCollections,
+  onCollect,
+  onRemoveFromUserCollection,
+  onStartRoom,
   onToggleNsfw,
   onShadowbanOwner,
   onDelete,
@@ -233,6 +386,9 @@ function CollectionDetailPage({
   onTagClick: (tag: TagName, sourceTags: string[]) => void;
   onEditTags: (pet: Pet) => void;
   onManageCollections: (pet: Pet) => void;
+  onCollect?: (pet: Pet) => void;
+  onRemoveFromUserCollection?: (pet: Pet) => void;
+  onStartRoom?: () => void;
   onToggleNsfw: (pet: Pet) => void;
   onShadowbanOwner: (pet: Pet) => void;
   onDelete: (pet: Pet) => void;
@@ -288,14 +444,27 @@ function CollectionDetailPage({
                 <Icon name="share" size={13} />
                 Share
               </button>
-              <a
-                className="btn btnSm btnPrimary collectionCardPlay"
-                href={`#/collections/${collection.slug}/play`}
-                aria-label={`Join ${collection.displayName} playground`}
-              >
-                <Icon name="play" size={11} />
-                Join
-              </a>
+              {collection.ownerId ? (
+                <button
+                  className="btn btnSm btnPrimary collectionCardPlay"
+                  type="button"
+                  disabled={!pets.length}
+                  onClick={onStartRoom}
+                  aria-label={`Start ${collection.displayName} room`}
+                >
+                  <Icon name="play" size={11} />
+                  Room
+                </button>
+              ) : (
+                <a
+                  className="btn btnSm btnPrimary collectionCardPlay"
+                  href={`#/collections/${collection.slug}/play`}
+                  aria-label={`Join ${collection.displayName} playground`}
+                >
+                  <Icon name="play" size={11} />
+                  Join
+                </a>
+              )}
             </div>
           </div>
         )}
@@ -326,11 +495,18 @@ function CollectionDetailPage({
                 onTagClick={onTagClick}
                 onEditTags={onEditTags}
                 onManageCollections={onManageCollections}
+                onCollect={onCollect}
                 onToggleNsfw={onToggleNsfw}
                 onShadowbanOwner={onShadowbanOwner}
                 onDelete={onDelete}
                 onSignIn={onSignIn}
               />
+              {onRemoveFromUserCollection && (
+                <button className="btn btnSm btnGhost" type="button" onClick={() => onRemoveFromUserCollection(pet)}>
+                  <Icon name="trash" size={13} />
+                  Remove from collection
+                </button>
+              )}
             </div>
           ))}
         </div>

--- a/src/gallery/CreatorPages.tsx
+++ b/src/gallery/CreatorPages.tsx
@@ -32,6 +32,7 @@ export function CreatorPage({
   onTagClick,
   onEditTags,
   onManageCollections,
+  onCollect,
   onToggleNsfw,
   onShadowbanOwner,
   onDelete,
@@ -57,6 +58,7 @@ export function CreatorPage({
   onTagClick: (tag: TagName, sourceTags: string[]) => void;
   onEditTags: (pet: Pet) => void;
   onManageCollections: (pet: Pet) => void;
+  onCollect?: (pet: Pet) => void;
   onToggleNsfw: (pet: Pet) => void;
   onShadowbanOwner: (pet: Pet) => void;
   onDelete: (pet: Pet) => void;
@@ -111,6 +113,7 @@ export function CreatorPage({
                 onTagClick={onTagClick}
                 onEditTags={onEditTags}
                 onManageCollections={onManageCollections}
+                onCollect={onCollect}
                 onToggleNsfw={onToggleNsfw}
                 onShadowbanOwner={onShadowbanOwner}
                 onDelete={onDelete}
@@ -144,6 +147,7 @@ export function FavoritesPage({
   onTagClick,
   onEditTags,
   onManageCollections,
+  onCollect,
   onToggleNsfw,
   onShadowbanOwner,
   onDelete,
@@ -165,6 +169,7 @@ export function FavoritesPage({
   onTagClick: (tag: TagName, sourceTags: string[]) => void;
   onEditTags: (pet: Pet) => void;
   onManageCollections: (pet: Pet) => void;
+  onCollect?: (pet: Pet) => void;
   onToggleNsfw: (pet: Pet) => void;
   onShadowbanOwner: (pet: Pet) => void;
   onDelete: (pet: Pet) => void;
@@ -212,6 +217,7 @@ export function FavoritesPage({
                 onTagClick={onTagClick}
                 onEditTags={onEditTags}
                 onManageCollections={onManageCollections}
+                onCollect={onCollect}
                 onToggleNsfw={onToggleNsfw}
                 onShadowbanOwner={onShadowbanOwner}
                 onDelete={onDelete}

--- a/src/gallery/GalleryHome.tsx
+++ b/src/gallery/GalleryHome.tsx
@@ -169,6 +169,7 @@ function Gallery({
   onTagClick,
   onEditTags,
   onManageCollections,
+  onCollect,
   onToggleNsfw,
   onShadowbanOwner,
   onDelete,
@@ -208,6 +209,7 @@ function Gallery({
   onTagClick: (tag: TagName, sourceTags: string[]) => void;
   onEditTags: (pet: Pet) => void;
   onManageCollections: (pet: Pet) => void;
+  onCollect?: (pet: Pet) => void;
   onToggleNsfw: (pet: Pet) => void;
   onShadowbanOwner: (pet: Pet) => void;
   onDelete: (pet: Pet) => void;
@@ -278,6 +280,7 @@ function Gallery({
                 onTagClick={onTagClick}
                 onEditTags={onEditTags}
                 onManageCollections={onManageCollections}
+                onCollect={onCollect}
                 onPreview={canCursorPreview ? (previewTarget) =>
                   setPreviewPet((current) => (current?.id === previewTarget.id ? null : previewTarget))
                 : undefined}

--- a/src/gallery/gallery-card-actions.css
+++ b/src/gallery/gallery-card-actions.css
@@ -90,6 +90,14 @@
   color: var(--accent-deep);
 }
 
+.petCardActions .btnDanger {
+  color: var(--danger-fg);
+}
+
+.petCardActions .btnDanger:hover:not(:disabled) {
+  color: var(--danger-fg-hover);
+}
+
 .petCardActions .likeButton.active .icon {
   color: #d92d20;
   fill: #d92d20;

--- a/src/gallery/gallery-card-grid.css
+++ b/src/gallery/gallery-card-grid.css
@@ -48,8 +48,8 @@
   min-height: 126px;
   padding: 8px 18px;
   background:
-    radial-gradient(circle at 50% 48%, rgba(228, 225, 217, 0.74) 0%, #ffffff 72%),
-    #ffffff;
+    radial-gradient(circle at 50% 48%, var(--preview-halo) 0%, var(--preview-surface) 72%),
+    var(--preview-surface);
   border: 0;
   border-bottom: 1px solid var(--border-soft);
   cursor: pointer;
@@ -72,7 +72,7 @@
   height: 28px;
   padding: 0;
   border-radius: 999px;
-  background: rgba(255, 255, 255, 0.92);
+  background: var(--floating-control-bg);
   border: 1px solid var(--border);
   color: var(--muted);
   cursor: pointer;
@@ -82,7 +82,7 @@
 }
 
 .petCardQuickAction:hover:not(:disabled) {
-  background: #ffffff;
+  background: var(--floating-control-bg-hover);
   border-color: var(--border-strong);
   color: var(--ink);
   transform: translateY(-1px);

--- a/src/gallery/gallery-live-chips.css
+++ b/src/gallery/gallery-live-chips.css
@@ -12,9 +12,9 @@
   gap: 6px;
   padding: 2px 8px 2px 7px;
   border-radius: 999px;
-  background: rgba(247, 226, 200, 0.55);
-  border: 1px solid rgba(177, 90, 22, 0.22);
-  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.5);
+  background: var(--accent-soft);
+  border: 1px solid var(--accent-glow);
+  box-shadow: inset 0 1px 0 var(--inset-highlight);
   color: var(--accent-deep, #8a4a16);
   font-family: var(--font-mono);
   font-size: 10px;
@@ -93,8 +93,8 @@
   z-index: 1;
   /* Slightly stronger materiality than the inline chip — it floats
      over the preview, so a touch more contrast helps it read. */
-  background: rgba(255, 244, 222, 0.92);
-  border-color: rgba(177, 90, 22, 0.32);
+  background: var(--floating-control-bg);
+  border-color: var(--border-strong);
   backdrop-filter: blur(2px);
   -webkit-backdrop-filter: blur(2px);
   /* Interactive: clicking the pill jumps straight to the playground.

--- a/src/gallery/gallery-live-rail.css
+++ b/src/gallery/gallery-live-rail.css
@@ -23,7 +23,7 @@
     width: 224px;
     max-height: calc(100vh - 120px);
     padding: 12px 12px 10px;
-    background: rgba(255, 255, 255, 0.72);
+    background: var(--rail-bg);
     border: 1px solid var(--border-soft, #efede5);
     border-radius: 14px;
     /* Diffusion shadow tinted toward the warm background — never a
@@ -261,7 +261,7 @@
   border-color: var(--accent-deep, #b15a16);
   background: var(--accent-soft, #f7e2c8);
   color: var(--accent-deep, #b15a16);
-  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.55);
+  box-shadow: inset 0 1px 0 var(--inset-highlight);
 }
 
 .collectionCardPlay:hover:not(:disabled),

--- a/src/pets/PetCard.tsx
+++ b/src/pets/PetCard.tsx
@@ -129,6 +129,7 @@ export function PetCard({
   onTagClick,
   onEditTags,
   onManageCollections,
+  onCollect,
   onPreview,
   previewActive = false,
   onToggleNsfw,
@@ -152,6 +153,7 @@ export function PetCard({
   onTagClick: (tag: TagName, sourceTags: string[]) => void;
   onEditTags: (pet: Pet) => void;
   onManageCollections: (pet: Pet) => void;
+  onCollect?: (pet: Pet) => void;
   onPreview?: (pet: Pet) => void;
   previewActive?: boolean;
   onToggleNsfw: (pet: Pet) => void;
@@ -268,6 +270,18 @@ export function PetCard({
           <Icon name="share" size={13} />
           {!compact && "Share"}
         </button>
+        {user && onCollect && (
+          <button
+            className="btn btnSm"
+            type="button"
+            aria-label="Collect"
+            title="Collect"
+            onClick={() => onCollect(pet)}
+          >
+            <Icon name="package" size={13} />
+            {!compact && "Collect"}
+          </button>
+        )}
         {user?.isAdmin && (
           <AdminPetMenu
             pet={pet}

--- a/src/pets/PetCard.tsx
+++ b/src/pets/PetCard.tsx
@@ -130,6 +130,7 @@ export function PetCard({
   onEditTags,
   onManageCollections,
   onCollect,
+  onRemoveFromCollection,
   onPreview,
   previewActive = false,
   onToggleNsfw,
@@ -154,6 +155,7 @@ export function PetCard({
   onEditTags: (pet: Pet) => void;
   onManageCollections: (pet: Pet) => void;
   onCollect?: (pet: Pet) => void;
+  onRemoveFromCollection?: (pet: Pet) => void;
   onPreview?: (pet: Pet) => void;
   previewActive?: boolean;
   onToggleNsfw: (pet: Pet) => void;
@@ -274,12 +276,24 @@ export function PetCard({
           <button
             className="btn btnSm"
             type="button"
-            aria-label="Collect"
-            title="Collect"
+            aria-label="Add to collection"
+            title="Add to collection"
             onClick={() => onCollect(pet)}
           >
             <Icon name="package" size={13} />
-            {!compact && "Collect"}
+            {!compact && "Add to collection"}
+          </button>
+        )}
+        {onRemoveFromCollection && (
+          <button
+            className="btn btnSm btnDanger"
+            type="button"
+            aria-label="Remove from collection"
+            title="Remove from collection"
+            onClick={() => onRemoveFromCollection(pet)}
+          >
+            <Icon name="trash" size={13} />
+            {!compact && "Remove"}
           </button>
         )}
         {user?.isAdmin && (

--- a/src/pets/PetDetail.tsx
+++ b/src/pets/PetDetail.tsx
@@ -32,6 +32,7 @@ export function PetDetail({
   onSignIn,
   onEditTags,
   onManageCollections,
+  onCollect,
   onToggleNsfw,
   onShadowbanOwner,
   onDelete
@@ -54,6 +55,7 @@ export function PetDetail({
   onSignIn: () => void;
   onEditTags: (pet: Pet) => void;
   onManageCollections: (pet: Pet) => void;
+  onCollect?: (pet: Pet) => void;
   onToggleNsfw: (pet: Pet) => void;
   onShadowbanOwner: (pet: Pet) => void;
   onDelete: (pet: Pet) => void;
@@ -157,6 +159,12 @@ export function PetDetail({
               >
                 <Icon name="cube" size={13} />
                 Playground
+              </button>
+            )}
+            {user && onCollect && (
+              <button className="btn btnSm" type="button" onClick={() => onCollect(pet)}>
+                <Icon name="package" size={13} />
+                Collect
               </button>
             )}
             {canDelete && (

--- a/src/pets/PetDetail.tsx
+++ b/src/pets/PetDetail.tsx
@@ -164,7 +164,7 @@ export function PetDetail({
             {user && onCollect && (
               <button className="btn btnSm" type="button" onClick={() => onCollect(pet)}>
                 <Icon name="package" size={13} />
-                Collect
+                Add to collection
               </button>
             )}
             {canDelete && (

--- a/src/pets/pet-surfaces.css
+++ b/src/pets/pet-surfaces.css
@@ -2,16 +2,16 @@
 .checker {
   background:
     radial-gradient(circle at 50% 38%, rgba(216, 242, 90, 0.24), transparent 58%),
-    radial-gradient(circle at 50% 82%, rgba(16, 16, 15, 0.06), transparent 60%),
-    linear-gradient(180deg, #fffdf5, var(--surface-warm));
+    radial-gradient(circle at 50% 82%, var(--preview-ground), transparent 60%),
+    linear-gradient(180deg, var(--preview-soft-top), var(--surface-warm));
   background-color: var(--tile-bg);
 }
 
 .previewSurface {
   background:
     radial-gradient(circle at 50% 38%, rgba(216, 242, 90, 0.24), transparent 58%),
-    radial-gradient(circle at 50% 82%, rgba(16, 16, 15, 0.06), transparent 60%),
-    linear-gradient(180deg, #fffdf5, var(--surface-warm));
+    radial-gradient(circle at 50% 82%, var(--preview-ground), transparent 60%),
+    linear-gradient(180deg, var(--preview-soft-top), var(--surface-warm));
   background-color: var(--tile-bg);
 }
 

--- a/src/share/share.css
+++ b/src/share/share.css
@@ -125,10 +125,10 @@
   height: 40px;
   gap: 9px;
   padding: 0 12px;
-  border: 1px solid #2a2926;
+  border: 1px solid var(--terminal-border);
   border-radius: var(--radius-sm);
-  background: var(--ink);
-  color: #e8e6e0;
+  background: var(--terminal-bg);
+  color: var(--terminal-fg);
 }
 
 .commandCopyButton {

--- a/src/ui/Icon.tsx
+++ b/src/ui/Icon.tsx
@@ -10,6 +10,7 @@ export type IconName =
   | "eye"
   | "github"
   | "heart"
+  | "moon"
   | "more"
   | "package"
   | "search"
@@ -23,7 +24,8 @@ export type IconName =
   | "x"
   | "play"
   | "link"
-  | "sparkle";
+  | "sparkle"
+  | "sun";
 
 export function Icon({ name, size = 16 }: { name: IconName; size?: number }) {
   const paths: Record<IconName, ReactNode> = {
@@ -74,6 +76,9 @@ export function Icon({ name, size = 16 }: { name: IconName; size?: number }) {
     ),
     heart: (
       <path d="M8 13.3 C5.35 11.1 2.5 8.85 2.5 5.85 C2.5 4.15 3.7 3 5.25 3 C6.25 3 7.15 3.55 8 4.55 C8.85 3.55 9.75 3 10.75 3 C12.3 3 13.5 4.15 13.5 5.85 C13.5 8.85 10.65 11.1 8 13.3 Z" />
+    ),
+    moon: (
+      <path d="M12.5 10.8 C11.55 11.95 10.1 12.7 8.45 12.7 C5.6 12.7 3.3 10.4 3.3 7.55 C3.3 5.45 4.55 3.6 6.35 2.8 C6.05 3.55 5.9 4.35 5.9 5.2 C5.9 8.25 8.35 10.7 11.4 10.7 C11.78 10.7 12.15 10.67 12.5 10.8 Z" />
     ),
     more: (
       <>
@@ -163,6 +168,19 @@ export function Icon({ name, size = 16 }: { name: IconName; size?: number }) {
     sparkle: (
       <>
         <path d="M8 2 L9 6.5 L13.5 8 L9 9.5 L8 14 L7 9.5 L2.5 8 L7 6.5 Z" />
+      </>
+    ),
+    sun: (
+      <>
+        <circle cx="8" cy="8" r="3" />
+        <path d="M8 1.8 V3.2" />
+        <path d="M8 12.8 V14.2" />
+        <path d="M1.8 8 H3.2" />
+        <path d="M12.8 8 H14.2" />
+        <path d="M3.6 3.6 L4.6 4.6" />
+        <path d="M11.4 11.4 L12.4 12.4" />
+        <path d="M12.4 3.6 L11.4 4.6" />
+        <path d="M4.6 11.4 L3.6 12.4" />
       </>
     )
   };


### PR DESCRIPTION
## Summary
- add owned user collections in the Cloudflare adapter, including an additive `owner_id` migration and collection share metadata
- add gallery UI for creating, editing, sharing, deleting, and collecting pets into user collections
- let users open an ephemeral room from a user collection
- add a persisted light/dark theme toggle in the main nav
- filter shadowbanned users out of the creators leaderboard

## Validation
- `npx tsc -b --pretty false`
- `npx tsc -p adapters/cloudflare-worker/tsconfig.json --pretty false`
- preview build and deploy to https://codex-pet-share-verify.omgrly.workers.dev
- preview API flow: register temp user, create user collection, fetch mine/detail/share page, create collection room, delete collection, clean up temp user
- Chrome preview check for the collections page and light/dark theme toggle
- scanned the branch diff for key/token/secret patterns; no sensitive values matched

## Notes
- `0002_user_collections.sql` is additive: it adds nullable `collections.owner_id` and an owner index.
- Production was only updated for the shadowbanned-creators hotfix; the user-collections/theme feature is on the preview Worker for PR review.