### PR TITLE
Add personal collection social previews

### DIFF
--- a/adapters/cloudflare-pages/functions/collections/[slug].js
+++ b/adapters/cloudflare-pages/functions/collections/[slug].js
@@ -35,13 +35,20 @@ export async function onRequestGet(context) {
   const compositeUrl = compositeManifest.has(collection.slug)
     ? `${appOrigin}/assets/social/collections/${collection.slug}.png?v=${cardVersion}`
     : null;
-  const imageUrl = compositeUrl
+  const personalImageUrl = collection.ownerId
+    ? `${apiBase}/api/collections/${encodeURIComponent(collection.slug)}/social-image?v=${encodeURIComponent(collection.updatedAt)}`
+    : null;
+  const imageUrl = personalImageUrl
+    || compositeUrl
     || (featured ? `${apiBase}/api/pets/${featured.id}/share-image` : fallbackImageUrl);
-  const imageAlt = compositeUrl
-    ? `${collection.displayName}, a curated ${appName} collection`
-    : (featured
-      ? `${featured.displayName}, a pet from the ${collection.displayName} collection`
-      : `${collection.displayName} on ${appName}`);
+  const imageType = personalImageUrl ? "image/svg+xml" : "image/png";
+  const imageAlt = personalImageUrl
+    ? `${collection.displayName}, a custom ${appName} collection`
+    : (compositeUrl
+      ? `${collection.displayName}, a curated ${appName} collection`
+      : (featured
+        ? `${featured.displayName}, a pet from the ${collection.displayName} collection`
+        : `${collection.displayName} on ${appName}`));
 
   return html(`<!doctype html>
 <html lang="en">
@@ -57,7 +64,7 @@ export async function onRequestGet(context) {
   <meta property="og:description" content="${escapeHtml(description)}">
   <meta property="og:image" content="${escapeHtml(imageUrl)}">
   <meta property="og:image:secure_url" content="${escapeHtml(imageUrl)}">
-  <meta property="og:image:type" content="image/png">
+  <meta property="og:image:type" content="${escapeHtml(imageType)}">
   <meta property="og:image:width" content="1200">
   <meta property="og:image:height" content="630">
   <meta property="og:image:alt" content="${escapeHtml(imageAlt)}">

--- a/adapters/cloudflare-worker/src/api/collections.ts
+++ b/adapters/cloudflare-worker/src/api/collections.ts
@@ -171,6 +171,7 @@ function collectionSummary(ctx: AppContext, row: CollectionRow, pets: PetRow[], 
   return {
     slug: row.slug,
     displayName: row.display_name,
+    updatedAt: row.updated_at,
     ownerId,
     editable: Boolean(ownerId && viewer?.id === ownerId),
     petCount: pets.length,

--- a/adapters/cloudflare-worker/src/api/share.ts
+++ b/adapters/cloudflare-worker/src/api/share.ts
@@ -2,6 +2,7 @@ import { collectionPets, collectionRow } from "./collections";
 import { currentUser, publicUser } from "./auth";
 import { getVisiblePet, listPets } from "./pets";
 import { slugPattern } from "./constants";
+import { collectionSocialPreviewImageUrl } from "./socialPreview";
 import { escapeHtml, html } from "../core/http";
 import { petAssetUrl } from "../storage/assets";
 import type { AppContext, Viewer } from "../core/types";
@@ -41,11 +42,7 @@ export async function handleEntityShare(ctx: AppContext, kind: "collections" | "
     const collection = await collectionRow(ctx, id);
     if (!collection) return html("<!doctype html><title>Collection not found</title>", 404);
     const pets = await collectionPets(ctx, collection.slug, "safe");
-    const featured = pets[0] || null;
-    const staticCollectionImage = `${ctx.env.PUBLIC_APP_ORIGIN}/assets/social/collections/${collection.slug}.png`;
-    const image = collection.owner_id
-      ? featured ? `${ctx.url.origin}/api/pets/${featured.id}/share-image` : `${ctx.env.PUBLIC_APP_ORIGIN}/assets/petshare-social-preview.png`
-      : staticCollectionImage;
+    const image = await collectionSocialPreviewImageUrl(ctx, collection, pets);
     return entityHtml(ctx, {
       title: collection.display_name,
       description: `${pets.length} pets in ${ctx.env.APP_NAME}`,

--- a/adapters/cloudflare-worker/src/api/socialPreview.ts
+++ b/adapters/cloudflare-worker/src/api/socialPreview.ts
@@ -1,0 +1,212 @@
+import { collectionPets, collectionRow } from "./collections";
+import { first } from "../core/db";
+import { HttpError, html } from "../core/http";
+import { petAssetKey, petAssetUrl } from "../storage/assets";
+import type { AppContext, CollectionRow, PetRow } from "../core/types";
+
+const cardWidth = 1200;
+const cardHeight = 630;
+const previewFrameWidth = 96;
+const previewFrameHeight = 104;
+const previewStripWidth = 5472;
+const previewStripHeight = 104;
+const maxPets = 8;
+
+type CollectionOwner = {
+  handle: string;
+  display_name: string;
+  updated_at: string;
+};
+
+export async function handleCollectionSocialImage(ctx: AppContext, slug?: string) {
+  if (!slug) return html("<svg xmlns=\"http://www.w3.org/2000/svg\"/>", 404, { "Content-Type": "image/svg+xml; charset=utf-8" });
+  const collection = await collectionRow(ctx, slug);
+  if (!collection) return html("<svg xmlns=\"http://www.w3.org/2000/svg\"/>", 404, { "Content-Type": "image/svg+xml; charset=utf-8" });
+  const owner = collection.owner_id ? await collectionOwner(ctx, collection.owner_id) : null;
+  const pets = await collectionPets(ctx, collection.slug, "safe");
+  const version = collectionSocialPreviewVersion(collection, owner, pets);
+  const key = collectionSocialPreviewKey(ctx, collection.slug);
+  const cached = await ctx.env.PET_ASSETS.get(key);
+  if (cached?.customMetadata?.version === version) {
+    return socialImageResponse(cached.body, cached.httpEtag, version);
+  }
+  const svg = collectionSocialPreviewSvg(ctx, { collection, owner, pets });
+  await ctx.env.PET_ASSETS.put(key, svg, {
+    httpMetadata: {
+      contentType: "image/svg+xml; charset=utf-8",
+      cacheControl: "public, max-age=31536000, immutable"
+    },
+    customMetadata: { version }
+  });
+  return socialImageResponse(svg, undefined, version);
+}
+
+export async function collectionSocialPreviewImageUrl(ctx: AppContext, collection: CollectionRow, pets: PetRow[]) {
+  if (!collection.owner_id) {
+    return `${ctx.env.PUBLIC_APP_ORIGIN}/assets/social/collections/${encodeURIComponent(collection.slug)}.png`;
+  }
+  const owner = await collectionOwner(ctx, collection.owner_id);
+  const version = collectionSocialPreviewVersion(collection, owner, pets);
+  return `${ctx.url.origin}/api/collections/${encodeURIComponent(collection.slug)}/social-image?v=${encodeURIComponent(version)}`;
+}
+
+function socialImageResponse(body: ReadableStream | string, etag: string | undefined, version: string) {
+  const headers = new Headers({
+    "Content-Type": "image/svg+xml; charset=utf-8",
+    "Cache-Control": "public, max-age=31536000, immutable",
+    "X-Petshare-Social-Version": version
+  });
+  if (etag) headers.set("ETag", etag);
+  return new Response(body, { headers });
+}
+
+function collectionSocialPreviewKey(ctx: AppContext, slug: string) {
+  return petAssetKey(ctx, `social/collections/${slug}.svg`);
+}
+
+async function collectionOwner(ctx: AppContext, ownerId: string) {
+  const owner = await first<CollectionOwner>(
+    ctx.env.DB.prepare("select handle, display_name, updated_at from users where id = ?").bind(ownerId)
+  );
+  if (!owner) throw new HttpError("collection owner not found", 404);
+  return owner;
+}
+
+function collectionSocialPreviewVersion(collection: CollectionRow, owner: CollectionOwner | null, pets: PetRow[]) {
+  return hashVersion([
+    collection.slug,
+    collection.display_name,
+    collection.updated_at,
+    owner?.handle || "",
+    owner?.display_name || "",
+    owner?.updated_at || "",
+    String(pets.length),
+    ...pets.slice(0, maxPets).map((pet) => `${pet.id}:${pet.updated_at}`)
+  ].join("|"));
+}
+
+function collectionSocialPreviewSvg(ctx: AppContext, {
+  collection,
+  owner,
+  pets
+}: {
+  collection: CollectionRow;
+  owner: CollectionOwner | null;
+  pets: PetRow[];
+}) {
+  const featuredPets = pets.slice(0, maxPets);
+  const titleLines = wrapText(collection.display_name, 24, 2);
+  const ownerLabel = owner ? `by ${owner.display_name}` : "curated collection";
+  const subtitle = `${ownerLabel} / ${pets.length} ${pets.length === 1 ? "pet" : "pets"}`;
+  const collectionUrl = collectionUrlLabel(ctx, collection.slug);
+  const petLayers = featuredPets.length ? petSpriteLayers(ctx, featuredPets) : emptyPetLayer();
+
+  return `<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" width="${cardWidth}" height="${cardHeight}" viewBox="0 0 ${cardWidth} ${cardHeight}">
+  <defs>
+    <pattern id="paper" x="0" y="0" width="36" height="36" patternUnits="userSpaceOnUse">
+      <rect width="36" height="36" fill="#f8f6f0"/>
+      <rect x="0" y="0" width="18" height="18" fill="#f1eee4"/>
+      <rect x="18" y="18" width="18" height="18" fill="#f1eee4"/>
+    </pattern>
+    <radialGradient id="glow" cx="68%" cy="44%" r="56%">
+      <stop offset="0%" stop-color="#d8f25a" stop-opacity="0.30"/>
+      <stop offset="70%" stop-color="#d8f25a" stop-opacity="0"/>
+    </radialGradient>
+    <filter id="soft-shadow" x="-20%" y="-20%" width="140%" height="140%">
+      <feDropShadow dx="0" dy="18" stdDeviation="18" flood-color="#10100f" flood-opacity="0.20"/>
+    </filter>
+  </defs>
+  <rect width="${cardWidth}" height="${cardHeight}" fill="url(#paper)"/>
+  <rect width="${cardWidth}" height="${cardHeight}" fill="url(#glow)"/>
+  <rect x="48" y="48" width="${cardWidth - 96}" height="${cardHeight - 96}" rx="22" fill="#fffdf5" stroke="#10100f" stroke-opacity="0.12"/>
+  <g transform="translate(92 92)">
+    <text x="0" y="0" font-family="ui-monospace, SFMono-Regular, Menlo, monospace" font-size="24" font-weight="700" fill="#65a30d" letter-spacing="1">$ ${escapeXml(ctx.env.APP_HANDLE)}</text>
+    ${titleLines.map((line, index) => `<text x="0" y="${104 + index * 70}" font-family="ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif" font-size="64" font-weight="850" fill="#10100f" letter-spacing="0">${escapeXml(line)}</text>`).join("\n    ")}
+    <text x="0" y="${260 + Math.max(titleLines.length - 1, 0) * 70}" font-family="ui-monospace, SFMono-Regular, Menlo, monospace" font-size="25" font-weight="600" fill="#6f6f69">${escapeXml(subtitle)}</text>
+    <text x="0" y="438" font-family="ui-monospace, SFMono-Regular, Menlo, monospace" font-size="20" fill="#8b877a">${escapeXml(collectionUrl)}</text>
+  </g>
+  <g filter="url(#soft-shadow)">
+    ${petLayers}
+  </g>
+</svg>`;
+}
+
+function petSpriteLayers(ctx: AppContext, pets: PetRow[]) {
+  const layout = socialGridLayout(pets.length);
+  const tileWidth = Math.round(previewFrameWidth * layout.scale);
+  const tileHeight = Math.round(previewFrameHeight * layout.scale);
+  const gridWidth = layout.cols * tileWidth + (layout.cols - 1) * layout.gap;
+  const startX = Math.round(cardWidth - gridWidth - 96);
+  return pets.slice(0, layout.cols * layout.rows).map((pet, index) => {
+    const col = index % layout.cols;
+    const row = Math.floor(index / layout.cols);
+    const x = startX + col * (tileWidth + layout.gap);
+    const y = layout.top + row * (tileHeight + layout.gap);
+    const version = String(Date.parse(pet.updated_at || pet.created_at));
+    const url = petAssetUrl(ctx, `${pet.id}/preview.webp`, version);
+    return `<svg x="${x}" y="${y}" width="${tileWidth}" height="${tileHeight}" viewBox="0 0 ${previewFrameWidth} ${previewFrameHeight}" overflow="hidden">
+      <image href="${escapeXml(url)}" x="0" y="0" width="${previewStripWidth}" height="${previewStripHeight}" image-rendering="pixelated"/>
+    </svg>`;
+  }).join("\n    ");
+}
+
+function emptyPetLayer() {
+  return `<g transform="translate(740 234)">
+    <rect width="300" height="170" rx="18" fill="#f4f2eb" stroke="#d2cec3"/>
+    <text x="150" y="88" text-anchor="middle" font-family="ui-monospace, SFMono-Regular, Menlo, monospace" font-size="23" fill="#6f6f69">No pets yet</text>
+  </g>`;
+}
+
+function socialGridLayout(count: number) {
+  if (count <= 1) return { cols: 1, rows: 1, scale: 1.75, top: 182, gap: 28 };
+  if (count <= 2) return { cols: 2, rows: 1, scale: 1.25, top: 218, gap: 28 };
+  if (count <= 4) return { cols: 2, rows: 2, scale: 1.0, top: 142, gap: 24 };
+  return { cols: 4, rows: 2, scale: 0.74, top: 168, gap: 18 };
+}
+
+function collectionUrlLabel(ctx: AppContext, slug: string) {
+  return `${ctx.env.PUBLIC_APP_ORIGIN.replace(/^https?:\/\//, "").replace(/\/$/, "")}/collections/${slug}`;
+}
+
+function wrapText(value: string, maxChars: number, maxLines: number) {
+  const words = value.trim().split(/\s+/).filter(Boolean);
+  const lines: string[] = [];
+  let current = "";
+  for (const word of words) {
+    const next = current ? `${current} ${word}` : word;
+    if (next.length > maxChars && current) {
+      lines.push(current);
+      current = word;
+      if (lines.length === maxLines) break;
+    } else {
+      current = next;
+    }
+  }
+  if (current && lines.length < maxLines) lines.push(current);
+  if (!lines.length) return ["Collection"];
+  const lastIndex = lines.length - 1;
+  if (lines[lastIndex].length > maxChars) {
+    lines[lastIndex] = `${lines[lastIndex].slice(0, maxChars - 3)}...`;
+  }
+  return lines;
+}
+
+function hashVersion(input: string) {
+  let hash = 2166136261;
+  for (let index = 0; index < input.length; index += 1) {
+    hash ^= input.charCodeAt(index);
+    hash = Math.imul(hash, 16777619);
+  }
+  return (hash >>> 0).toString(36);
+}
+
+function escapeXml(value: string) {
+  return value.replace(/[<>&'"]/g, (char) => ({
+    "<": "&lt;",
+    ">": "&gt;",
+    "&": "&amp;",
+    "'": "&apos;",
+    "\"": "&quot;"
+  })[char] || char);
+}

--- a/adapters/cloudflare-worker/src/index.ts
+++ b/adapters/cloudflare-worker/src/index.ts
@@ -3,6 +3,7 @@ import { handleAdmin, handleCollections, handleCreators, handleUsers } from "./a
 import { handlePets } from "./api/pets";
 import { handleRooms, roomAuth } from "./api/rooms";
 import { handleEntityShare, handleSharePet } from "./api/share";
+import { handleCollectionSocialImage } from "./api/socialPreview";
 import { isMaintenancePassthrough, maintenanceResponse } from "./maintenance";
 import { RoomDurableObject } from "./realtime/RoomDurableObject";
 import { HttpError, json, secureResponse } from "./core/http";
@@ -89,6 +90,7 @@ async function route(ctx: AppContext, parts: string[]) {
   if (parts[1] === "pets") return handlePets(ctx, parts.slice(2));
   if (parts[1] === "users") return handleUsers(ctx, parts.slice(2));
   if (parts[1] === "creators") return handleCreators(ctx, parts.slice(2));
+  if (ctx.request.method === "GET" && parts[1] === "collections" && parts[3] === "social-image" && parts.length === 4) return handleCollectionSocialImage(ctx, parts[2]);
   if (parts[1] === "collections") return handleCollections(ctx, parts.slice(2));
   if (parts[1] === "rooms") return handleRooms(ctx, parts.slice(2));
   return json({ error: "not found" }, 404);

--- a/src/app/AppRoutes.tsx
+++ b/src/app/AppRoutes.tsx
@@ -13,9 +13,9 @@ import {
 } from "../gallery/GalleryPages";
 import { UploadPage, YourUploads } from "../uploads/UploadPages";
 import {
-  collectionCompositeUrl,
   collectionPlayShareUrl,
   collectionShareUrl,
+  collectionSocialPreviewUrl,
   creatorCompositeUrl,
   creatorShareUrl
 } from "../domain/share";
@@ -281,9 +281,7 @@ export function AppRoutes({
               title: collectionDetail.displayName,
               subtitle,
               shareUrl: collectionShareUrl(collectionDetail),
-              imageUrl: collectionDetail.ownerId
-                ? (collectionPets[0]?.shareImageUrl || collectionCompositeUrl(collectionDetail.slug))
-                : collectionCompositeUrl(collectionDetail.slug),
+              imageUrl: collectionSocialPreviewUrl(collectionDetail),
               shareText: `${collectionDetail.displayName} on ${APP_NAME}`,
               ariaLabel: `Share ${collectionDetail.displayName}`
             });
@@ -401,8 +399,6 @@ export function AppRoutes({
   );
 }
 
-function collectionPreviewImage(collection: { slug: string; ownerId?: string | null; topPets?: Array<{ shareImageUrl: string }> }) {
-  return collection.ownerId
-    ? (collection.topPets?.[0]?.shareImageUrl || collectionCompositeUrl(collection.slug))
-    : collectionCompositeUrl(collection.slug);
+function collectionPreviewImage(collection: { slug: string; ownerId?: string | null; updatedAt: string }) {
+  return collectionSocialPreviewUrl(collection);
 }

--- a/src/domain/share.ts
+++ b/src/domain/share.ts
@@ -43,6 +43,11 @@ export function collectionCompositeUrl(slug: string): string {
   return `${publicAppOrigin}/assets/social/collections/${encodeURIComponent(slug)}.png`;
 }
 
+export function collectionSocialPreviewUrl(collection: { slug: string; ownerId?: string | null; updatedAt: string }) {
+  if (!collection.ownerId) return collectionCompositeUrl(collection.slug);
+  return `${publicAppOrigin}/api/collections/${encodeURIComponent(collection.slug)}/social-image?v=${encodeURIComponent(collection.updatedAt)}`;
+}
+
 export function creatorCompositeUrl(creator: { id: string; handle?: string | null }): string {
   return `${publicAppOrigin}/assets/social/creators/${encodeURIComponent(creator.handle || creator.id)}.png`;
 }

--- a/src/domain/types.ts
+++ b/src/domain/types.ts
@@ -119,6 +119,7 @@ export type CreatorsLeaderboardResponse = {
 export type CollectionSummary = {
   slug: string;
   displayName: string;
+  updatedAt: string;
   ownerId: string | null;
   editable?: boolean;
   petCount: number;


### PR DESCRIPTION
## Summary
- add a collection social-image API endpoint for user-owned collections
- use collection-level previews in worker and Pages share metadata
- expose collection updated timestamps so app share previews can cache-bust the generated image

## Verification
- npm run adapter:cloudflare:typecheck
- npx tsc -b --pretty false
- set -a; source .env.cloudflare.local; set +a; npm run build