### PR TITLE
Show owned pets in collection rooms

### DIFF
--- a/src/playground/room/useRoomPeerPalette.ts
+++ b/src/playground/room/useRoomPeerPalette.ts
@@ -17,21 +17,47 @@ export function useRoomPeerPalette({
     (async () => {
       try {
         if (collectionSlug) {
-          const res = await apiFetch(`/api/collections/${collectionSlug}`);
+          const [res, mineRes, favRes] = await Promise.all([
+            apiFetch(`/api/collections/${collectionSlug}`),
+            apiFetch("/api/pets/mine").catch(() => null as Response | null),
+            apiFetch("/api/pets/favorites").catch(() => null as Response | null)
+          ]);
           if (cancelled) return;
           if (!res.ok) {
             setPeers([]);
             return;
           }
           const body = await res.json() as { collection?: { topPets?: Pet[] }; pets?: Pet[] };
-          const pets = ((body.pets ?? body.collection?.topPets ?? []) as Pet[]).map(normalizePet);
+          const seen = new Set<string>();
+          const merged: PlaygroundPeer[] = [];
+          if (mineRes && mineRes.ok) {
+            const mineBody = await mineRes.json() as { pets: Pet[] };
+            for (const p of (mineBody.pets || []).map(normalizePet)) {
+              if (seen.has(p.id)) continue;
+              seen.add(p.id);
+              merged.push({ id: p.id, displayName: p.displayName, spritesheetUrl: p.spritesheetUrl, source: "own" });
+            }
+          }
+          if (favRes && favRes.ok) {
+            const favBody = await favRes.json() as { pets: Pet[] };
+            for (const p of (favBody.pets || []).map(normalizePet)) {
+              if (seen.has(p.id)) continue;
+              seen.add(p.id);
+              merged.push({ id: p.id, displayName: p.displayName, spritesheetUrl: p.spritesheetUrl, source: "favorite" });
+            }
+          }
+          for (const p of ((body.pets ?? body.collection?.topPets ?? []) as Pet[]).map(normalizePet)) {
+            if (seen.has(p.id)) continue;
+            seen.add(p.id);
+            merged.push({
+              id: p.id,
+              displayName: p.displayName,
+              spritesheetUrl: p.spritesheetUrl,
+              source: "collection"
+            });
+          }
           if (cancelled) return;
-          setPeers(pets.map((p) => ({
-            id: p.id,
-            displayName: p.displayName,
-            spritesheetUrl: p.spritesheetUrl,
-            source: "collection" as const
-          })));
+          setPeers(merged);
           return;
         }
 

--- a/src/playground/ui/PetPicker.tsx
+++ b/src/playground/ui/PetPicker.tsx
@@ -30,19 +30,35 @@ export function PetPicker({
     (async () => {
       try {
         if (collectionSlug) {
-          const res = await apiFetch(`/api/collections/${collectionSlug}`);
+          const [res, mineRes, favRes] = await Promise.all([
+            apiFetch(`/api/collections/${collectionSlug}`),
+            apiFetch("/api/pets/mine"),
+            apiFetch("/api/pets/favorites").catch(() => null as Response | null)
+          ]);
           if (cancelled) return;
           if (!res.ok) {
             setError("Couldn't load this collection.");
             return;
           }
+          if (!mineRes.ok) {
+            setError("Couldn't load your pets.");
+            return;
+          }
           const body = await res.json() as { collection?: { displayName?: string; topPets?: Pet[] }; pets?: Pet[] };
+          const mineBody = await mineRes.json() as { pets: Pet[] };
+          const own = (mineBody.pets || []).map(normalizePet);
+          let favs: Pet[] = [];
+          if (favRes && favRes.ok) {
+            const favBody = await favRes.json() as { pets: Pet[] };
+            const ownIds = new Set(own.map((p) => p.id));
+            favs = (favBody.pets || []).map(normalizePet).filter((p) => !ownIds.has(p.id));
+          }
           const pets = ((body.pets ?? body.collection?.topPets ?? []) as Pet[]).map(normalizePet);
           if (cancelled) return;
           setCollectionPets(pets);
           setCollectionLabel(body.collection?.displayName || collectionSlug);
-          setOwnPets([]);
-          setFavoritePets([]);
+          setOwnPets(own);
+          setFavoritePets(favs);
           return;
         }
         const [mineRes, favRes] = await Promise.all([
@@ -74,11 +90,9 @@ export function PetPicker({
   }, [apiFetch, collectionSlug]);
 
   const loaded = collectionSlug
-    ? collectionPets !== null
-    : (ownPets !== null && favoritePets !== null);
-  const totalCount = collectionSlug
-    ? (collectionPets?.length ?? 0)
-    : (ownPets?.length ?? 0) + (favoritePets?.length ?? 0);
+    ? collectionPets !== null && ownPets !== null && favoritePets !== null
+    : ownPets !== null && favoritePets !== null;
+  const totalCount = (collectionPets?.length ?? 0) + (ownPets?.length ?? 0) + (favoritePets?.length ?? 0);
 
   const [fallbackPets, setFallbackPets] = useState<Pet[] | null>(null);
   const needsFallback = !collectionSlug && loaded && totalCount === 0;
@@ -141,7 +155,7 @@ export function PetPicker({
         </header>
         <p className="roomGateLead">
           {collectionSlug
-            ? `Pick a pet from ${collectionLabel ? `the “${collectionLabel}” collection` : "this collection"}.`
+            ? `Pick a pet from ${collectionLabel ? `the “${collectionLabel}” collection` : "this collection"} or your own uploads.`
             : "Pick the pet you'll show up as."}
         </p>
         {error && <p className="status">{error}</p>}
@@ -156,13 +170,13 @@ export function PetPicker({
             </div>
           </div>
         )}
-        {loaded && collectionSlug && collectionPets && collectionPets.length === 0 && (
+        {loaded && collectionSlug && totalCount === 0 && (
           <div className="roomGateEmpty">
             <p>This collection has no pets yet.</p>
             <button className="btn btnGhost" type="button" onClick={onClose}>Close</button>
           </div>
         )}
-        {loaded && !collectionSlug && ownPets && ownPets.length > 0 && (
+        {loaded && ownPets && ownPets.length > 0 && (
           <div className="roomPetSection">
             <h3 className="roomPetSectionLabel">Yours</h3>
             <div className="roomPetGrid">
@@ -170,7 +184,7 @@ export function PetPicker({
             </div>
           </div>
         )}
-        {loaded && !collectionSlug && favoritePets && favoritePets.length > 0 && (
+        {loaded && favoritePets && favoritePets.length > 0 && (
           <div className="roomPetSection">
             <h3 className="roomPetSectionLabel">Favorites</h3>
             <div className="roomPetGrid">

--- a/src/playground/ui/npcSearchPopover.tsx
+++ b/src/playground/ui/npcSearchPopover.tsx
@@ -24,7 +24,7 @@ export function NpcSearchPopover({
   }, []);
 
   const trimmed = query.trim().toLowerCase();
-  const noFavorites = peers.length === 0;
+  const noPets = peers.length === 0;
   const matches = peers
     .filter((peer) => !excludeIds.includes(peer.id))
     .filter((peer) => trimmed.length === 0 || peer.displayName.toLowerCase().includes(trimmed));
@@ -35,10 +35,10 @@ export function NpcSearchPopover({
         ref={inputRef}
         type="text"
         className="playgroundNpcSearchInput"
-        placeholder={noFavorites ? "No favorites yet…" : "Search favorites…"}
+        placeholder={noPets ? "No pets available…" : "Search pets…"}
         value={query}
         onChange={(event) => onQueryChange(event.target.value)}
-        disabled={noFavorites}
+        disabled={noPets}
         onKeyDown={(event) => {
           if (event.key === "Escape") {
             event.preventDefault();
@@ -50,12 +50,12 @@ export function NpcSearchPopover({
         }}
       />
       <ul className="playgroundNpcSearchList">
-        {noFavorites && (
+        {noPets && (
           <li className="playgroundNpcSearchEmpty">
-            Heart pets you like to spawn them here.
+            No pets available.
           </li>
         )}
-        {!noFavorites && matches.length === 0 && (
+        {!noPets && matches.length === 0 && (
           <li className="playgroundNpcSearchEmpty">No matches</li>
         )}
         {matches.map((peer) => (


### PR DESCRIPTION
Summary:
- load your uploads and favorites alongside collection pets in collection-room pickers
- include those pets in the in-room switcher and NPC picker

Verification:
- npm run adapter:cloudflare:typecheck
- npx tsc -b --pretty false
- set -a; source .env.cloudflare.local; set +a; npm run build
- deployed to codex-pets.net as version cad15c28-4519-4844-a528-6b66c6a9b736