### PR TITLE
Add gallery refresh CTA and collection labels

### DIFF
--- a/adapters/cloudflare-worker/src/api/collections.ts
+++ b/adapters/cloudflare-worker/src/api/collections.ts
@@ -140,7 +140,7 @@ export async function handleAdmin(ctx: AppContext, parts: string[]) {
 
 export async function publicCollections(ctx: AppContext, content = "safe") {
   const rows = await all<CollectionRow>(ctx.env.DB.prepare("select * from collections where owner_id is null order by display_name asc, slug asc"));
-  return Promise.all(rows.map((row) => collectionSummaryForRow(ctx, row, content)));
+  return Promise.all(rows.map((row) => collectionSummaryForRow(ctx, row, content, null, true)));
 }
 
 export async function collectionRow(ctx: AppContext, slug: string) {

--- a/adapters/cloudflare-worker/src/api/share.ts
+++ b/adapters/cloudflare-worker/src/api/share.ts
@@ -114,7 +114,178 @@ function entityHtml(ctx: AppContext, input: { title: string; description: string
   <meta name="twitter:title" content="${escapeHtml(input.title)}">
   <meta name="twitter:description" content="${escapeHtml(input.description)}">
   <meta name="twitter:image" content="${escapeHtml(input.image)}">
+  <style>
+    :root {
+      color-scheme: light;
+      --ink: #161512;
+      --muted: #746f65;
+      --line: #ddd5c4;
+      --panel: #f6f0df;
+      --accent: #6e941f;
+      --accent-dark: #38530d;
+    }
+    * {
+      box-sizing: border-box;
+    }
+    body {
+      min-height: 100vh;
+      margin: 0;
+      display: grid;
+      place-items: center;
+      padding: 24px;
+      color: var(--ink);
+      background:
+        linear-gradient(rgba(255, 253, 247, 0.78), rgba(255, 253, 247, 0.78)),
+        radial-gradient(circle at 18% 20%, rgba(202, 224, 138, 0.38), transparent 34%),
+        radial-gradient(circle at 82% 78%, rgba(235, 191, 110, 0.28), transparent 30%),
+        var(--panel);
+      font-family: "Cabinet Grotesk", ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+    }
+    a {
+      color: inherit;
+    }
+    .shareShell {
+      width: min(960px, 100%);
+      padding: 18px;
+      border: 1px solid var(--line);
+      border-radius: 8px;
+      background: rgba(255, 253, 247, 0.86);
+      box-shadow: 0 28px 80px rgba(45, 38, 23, 0.16);
+    }
+    .sharePanel {
+      display: grid;
+      grid-template-columns: minmax(0, 1.08fr) minmax(280px, 0.92fr);
+      gap: 18px;
+      align-items: stretch;
+    }
+    .shareImage {
+      width: 100%;
+      height: auto;
+      min-height: 360px;
+      display: block;
+      object-fit: contain;
+      border: 1px solid var(--line);
+      border-radius: 8px;
+      background:
+        linear-gradient(45deg, rgba(142, 132, 104, 0.12) 25%, transparent 25%),
+        linear-gradient(-45deg, rgba(142, 132, 104, 0.12) 25%, transparent 25%),
+        linear-gradient(45deg, transparent 75%, rgba(142, 132, 104, 0.12) 75%),
+        linear-gradient(-45deg, transparent 75%, rgba(142, 132, 104, 0.12) 75%),
+        #f6f0df;
+      background-position: 0 0, 0 12px, 12px -12px, -12px 0;
+      background-size: 24px 24px;
+    }
+    .shareCopy {
+      min-height: 360px;
+      display: flex;
+      flex-direction: column;
+      justify-content: center;
+      padding: clamp(22px, 5vw, 48px);
+      border: 1px dashed var(--line);
+      border-radius: 8px;
+      background: linear-gradient(180deg, #fffaf0, #f7efd9);
+    }
+    .shareCopy h1 {
+      margin: 0 0 14px;
+      font-size: 64px;
+      line-height: 0.92;
+      letter-spacing: 0;
+      overflow-wrap: anywhere;
+    }
+    .shareCopy p {
+      max-width: 38rem;
+      margin: 0 0 14px;
+      color: var(--muted);
+      font-size: 18px;
+      line-height: 1.45;
+    }
+    .shareCopy p:last-of-type {
+      margin-bottom: 28px;
+      color: var(--ink);
+      font-weight: 700;
+      text-transform: uppercase;
+      letter-spacing: 0.08em;
+      font-size: 12px;
+    }
+    .shareCta {
+      width: fit-content;
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      gap: 10px;
+      min-height: 46px;
+      padding: 0 18px;
+      border: 1px solid #86a83b;
+      border-radius: 10px;
+      background: #e5f6b7;
+      color: var(--accent-dark);
+      box-shadow: inset 0 -2px 0 rgba(56, 83, 13, 0.13);
+      font-weight: 800;
+      text-decoration: none;
+      text-transform: uppercase;
+      letter-spacing: 0.09em;
+      font-size: 13px;
+    }
+    .shareCta:hover,
+    .shareCta:focus-visible {
+      background: #d9f09d;
+      border-color: var(--accent);
+      outline: none;
+    }
+    .shareMeta {
+      display: flex;
+      justify-content: space-between;
+      gap: 12px;
+      margin-bottom: 14px;
+      color: var(--muted);
+      font-family: "JetBrains Mono", ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+      font-size: 12px;
+      letter-spacing: 0.12em;
+      text-transform: uppercase;
+    }
+    @media (max-width: 760px) {
+      body {
+        padding: 12px;
+      }
+      .shareShell {
+        padding: 12px;
+      }
+      .sharePanel {
+        grid-template-columns: 1fr;
+      }
+      .shareImage {
+        min-height: 0;
+        aspect-ratio: 1200 / 630;
+      }
+      .shareCopy {
+        min-height: 0;
+      }
+      .shareMeta {
+        flex-direction: column;
+      }
+      .shareCopy h1 {
+        font-size: 42px;
+      }
+      .shareCopy p {
+        font-size: 16px;
+      }
+    }
+  </style>
 </head>
-<body><main>${input.body}<p><a href="${escapeHtml(input.canonical)}">Open in ${escapeHtml(ctx.env.APP_NAME)}</a></p></main></body>
+<body>
+  <main class="shareShell">
+    <div class="shareMeta">
+      <span>${escapeHtml(ctx.env.APP_NAME)}</span>
+      <span>Share page</span>
+    </div>
+    <section class="sharePanel" aria-label="${escapeHtml(input.title)}">
+      <img class="shareImage" src="${escapeHtml(input.image)}" alt="">
+      <div class="shareCopy">
+        ${input.body}
+        <a class="shareCta" href="${escapeHtml(input.canonical)}">Open in ${escapeHtml(ctx.env.APP_NAME)}</a>
+      </div>
+    </section>
+  </main>
+</body>
 </html>`);
 }

--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -55,6 +55,8 @@ function App() {
     selectKind,
     selectPage,
     randomizeGallery,
+    freshPetCount,
+    showFreshPets,
     selectVisibleTag,
     removePetFromGallery
   } = useGalleryBrowser({ apiFetch, session, route, setRoute });
@@ -393,6 +395,7 @@ function App() {
       contentMode, deletingPetId, shadowbanBusyOwnerId, nsfwBusyId, collections, userCollections,
       userCollectionsLoading, setQuery, selectTag,
       clearTags, selectSort, selectView, selectKind, selectContentMode, selectPage, randomizeGallery,
+      freshPetCount, showFreshPets,
       submitSearch, likeBusyId, toggleLike, setSharingPet, setPlaygroundPet, setDownloadPet,
       selectVisibleTag, openTagEditor, openCollectionEditor, togglePetNsfw, toggleOwnerShadowban,
       openPetCollector: userCollectionActions.openPetCollector,

--- a/src/app/AppRoutes.tsx
+++ b/src/app/AppRoutes.tsx
@@ -53,6 +53,8 @@ export function AppRoutes({
   selectContentMode,
   selectPage,
   randomizeGallery,
+  freshPetCount,
+  showFreshPets,
   submitSearch,
   likeBusyId,
   toggleLike,
@@ -140,6 +142,8 @@ export function AppRoutes({
           onContentMode={selectContentMode}
           onPage={selectPage}
           onRandomize={randomizeGallery}
+          freshPetCount={freshPetCount}
+          onFreshPets={showFreshPets}
           onSearch={submitSearch}
           user={user}
           likeBusyId={likeBusyId}

--- a/src/app/AppRoutes.types.ts
+++ b/src/app/AppRoutes.types.ts
@@ -49,6 +49,8 @@ export type AppRoutesProps = {
   selectContentMode: (mode: ContentMode) => void | Promise<void>;
   selectPage: (page: number) => void | Promise<void>;
   randomizeGallery: () => void | Promise<void>;
+  freshPetCount: number;
+  showFreshPets: () => void | Promise<void>;
   submitSearch: (event: FormEvent) => void | Promise<void>;
   likeBusyId: string;
   toggleLike: (pet: Pet) => void | Promise<void>;

--- a/src/app/responsive.css
+++ b/src/app/responsive.css
@@ -193,6 +193,22 @@
     text-align: left;
   }
 
+  .galleryStatusRow.hasFresh .resultBar {
+    padding-right: 0;
+  }
+
+  .freshPetsNotice {
+    top: auto;
+    right: 0;
+    bottom: 8px;
+    width: min(260px, 100%);
+    transform: none;
+  }
+
+  .freshPetsNotice .btn {
+    justify-content: center;
+  }
+
   .tagDropdown,
   .tagDropdownTrigger {
     width: 100%;

--- a/src/gallery/GalleryHome.tsx
+++ b/src/gallery/GalleryHome.tsx
@@ -1,4 +1,4 @@
-import { type CSSProperties, type FormEvent, useEffect, useState } from "react";
+import { type CSSProperties, type FormEvent, useEffect, useMemo, useState } from "react";
 import { type TagName } from "../domain/config";
 import type { AuthSession, CollectionSummary, ContentMode, GalleryMeta, GallerySort, GalleryView, Pet, PetKind, User } from "../domain/types";
 import { useCollectionPresenceCounts } from "../realtime/useCollectionPresenceCounts";
@@ -159,6 +159,8 @@ function Gallery({
   onContentMode,
   onPage,
   onRandomize,
+  freshPetCount,
+  onFreshPets,
   onSearch,
   user,
   likeBusyId,
@@ -199,6 +201,8 @@ function Gallery({
   onContentMode: (value: ContentMode) => void;
   onPage: (page: number) => void;
   onRandomize: () => void;
+  freshPetCount: number;
+  onFreshPets: () => void;
   onSearch: (event: FormEvent) => void;
   user: User | null;
   likeBusyId: string;
@@ -220,6 +224,18 @@ function Gallery({
   const cursorPreviewEnabled = Boolean(previewPet && canCursorPreview);
   const cursorPreviewReady = useCursorPreviewAssets(previewPet, cursorPreviewEnabled);
   const { cursorPoint, cursorStateId, cursorRotationDeg } = useCursorPreviewMotion(cursorPreviewEnabled);
+  const publicCollectionByPetId = useMemo(() => {
+    const byPetId = new Map<string, Pick<CollectionSummary, "slug" | "displayName">>();
+    for (const collection of collections) {
+      if (collection.ownerId) continue;
+      for (const petId of collection.petIds ?? []) {
+        if (!byPetId.has(petId)) {
+          byPetId.set(petId, { slug: collection.slug, displayName: collection.displayName });
+        }
+      }
+    }
+    return byPetId;
+  }, [collections]);
 
   useEffect(() => {
     if (!canCursorPreview) {
@@ -252,46 +268,68 @@ function Gallery({
         onContentMode={onContentMode}
         onSubmit={onSearch}
       />
-      <ResultBar meta={meta} loading={loading} />
+      <div className={`galleryStatusRow ${freshPetCount > 0 ? "hasFresh" : ""}`}>
+        <ResultBar meta={meta} loading={loading} />
+        {freshPetCount > 0 && (
+          <div className="freshPetsNotice" role="status">
+            <div>
+              <p className="freshPetsEyebrow">
+                <span className="freshPetsDot" aria-hidden="true" />
+                New upload{freshPetCount === 1 ? "" : "s"}
+              </p>
+              <p className="freshPetsCopy">
+                {freshPetCount} new pet{freshPetCount === 1 ? "" : "s"} ready.
+              </p>
+            </div>
+            <button className="btn btnPrimary" type="button" disabled={loading} onClick={onFreshPets}>
+              <Icon name="sparkle" size={13} />
+              Show
+            </button>
+          </div>
+        )}
+      </div>
       {loading ? (
         <GallerySkeleton view={activeView} />
       ) : pets.length ? (
-        <div className={`galleryGrid ${activeView}`}>
-          {pets.map((pet, index) => (
-            <div
-              className="revealItem"
-              key={pet.id}
-              style={{ "--delay": `${index * 60}ms` } as CSSProperties}
-            >
-              <PetCard
-                pet={pet}
-                view={activeView}
-                user={user}
-                likeBusyId={likeBusyId}
-                deletingPetId={deletingPetId}
-                shadowbanBusyOwnerId={shadowbanBusyOwnerId}
-                nsfwBusyId={nsfwBusyId}
-                contentMode={contentMode}
-                hasCollections={hasCollections}
-                onLike={onLike}
-                onShare={onShare}
-                onPlayground={onPlayground}
-                onDownload={onDownload}
-                onTagClick={onTagClick}
-                onEditTags={onEditTags}
-                onManageCollections={onManageCollections}
-                onCollect={onCollect}
-                onPreview={canCursorPreview ? (previewTarget) =>
-                  setPreviewPet((current) => (current?.id === previewTarget.id ? null : previewTarget))
-                : undefined}
-                previewActive={previewPet?.id === pet.id}
-                onToggleNsfw={onToggleNsfw}
-                onShadowbanOwner={onShadowbanOwner}
-                onDelete={onDelete}
-                onSignIn={onSignIn}
-              />
-            </div>
-          ))}
+        <div className="galleryResultsShell">
+          <div className={`galleryGrid ${activeView}`}>
+            {pets.map((pet, index) => (
+              <div
+                className="revealItem"
+                key={pet.id}
+                style={{ "--delay": `${index * 60}ms` } as CSSProperties}
+              >
+                <PetCard
+                  pet={pet}
+                  view={activeView}
+                  user={user}
+                  likeBusyId={likeBusyId}
+                  deletingPetId={deletingPetId}
+                  shadowbanBusyOwnerId={shadowbanBusyOwnerId}
+                  nsfwBusyId={nsfwBusyId}
+                  contentMode={contentMode}
+                  hasCollections={hasCollections}
+                  collectionBadge={publicCollectionByPetId.get(pet.id)}
+                  onLike={onLike}
+                  onShare={onShare}
+                  onPlayground={onPlayground}
+                  onDownload={onDownload}
+                  onTagClick={onTagClick}
+                  onEditTags={onEditTags}
+                  onManageCollections={onManageCollections}
+                  onCollect={onCollect}
+                  onPreview={canCursorPreview ? (previewTarget) =>
+                    setPreviewPet((current) => (current?.id === previewTarget.id ? null : previewTarget))
+                  : undefined}
+                  previewActive={previewPet?.id === pet.id}
+                  onToggleNsfw={onToggleNsfw}
+                  onShadowbanOwner={onShadowbanOwner}
+                  onDelete={onDelete}
+                  onSignIn={onSignIn}
+                />
+              </div>
+            ))}
+          </div>
         </div>
       ) : (
         <EmptyState text="No pets found." />

--- a/src/gallery/gallery-card-grid.css
+++ b/src/gallery/gallery-card-grid.css
@@ -257,6 +257,54 @@
   font-size: 15px;
 }
 
+.petCardCollectionPill {
+  position: absolute;
+  top: 8px;
+  left: 8px;
+  z-index: 5;
+  display: inline-flex;
+  align-items: center;
+  max-width: calc(100% - 76px);
+  gap: 6px;
+  min-height: 26px;
+  padding: 0 10px;
+  border: 1px solid color-mix(in srgb, var(--accent) 30%, var(--border));
+  border-radius: 6px;
+  background: color-mix(in srgb, var(--accent-soft) 74%, var(--surface));
+  color: var(--accent-deep);
+  font-family: var(--font-mono);
+  font-size: 11px;
+  font-weight: 600;
+  letter-spacing: 0;
+  line-height: 1;
+  text-decoration: none;
+  transition: background 160ms var(--ease-out), border-color 160ms var(--ease-out),
+    color 160ms var(--ease-out), transform 160ms var(--ease-out);
+}
+
+.petCardCollectionPill span {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.petCardCollectionPill:hover,
+.petCardCollectionPill:focus-visible {
+  border-color: var(--accent-deep);
+  background: color-mix(in srgb, var(--accent-soft) 82%, var(--surface));
+  color: var(--ink);
+  transform: translateY(-1px);
+}
+
+.petCard.compact .petCardCollectionPill {
+  top: 6px;
+  left: 6px;
+  max-width: calc(100% - 60px);
+  min-height: 22px;
+  padding: 0 8px;
+  font-size: 10px;
+}
+
 .collectionsGrid {
   display: grid;
   grid-template-columns: repeat(auto-fill, minmax(260px, 1fr));

--- a/src/gallery/gallery-controls.css
+++ b/src/gallery/gallery-controls.css
@@ -46,6 +46,114 @@
   text-align: right;
 }
 
+.galleryStatusRow {
+  position: relative;
+  min-height: 46px;
+  margin: 0 0 14px;
+  border-top: 1px solid var(--border-soft);
+}
+
+.galleryStatusRow .resultBar {
+  min-height: 46px;
+  margin: 0;
+  padding: 10px 0;
+  border-top: 0;
+}
+
+.galleryStatusRow.hasFresh .resultBar {
+  padding-right: min(310px, 42vw);
+}
+
+.freshPetsNotice {
+  position: absolute;
+  top: 50%;
+  right: 0;
+  z-index: 6;
+  width: fit-content;
+  max-width: 100%;
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  align-items: center;
+  gap: 10px;
+  margin: 0;
+  padding: 9px 10px 9px 12px;
+  border: 1px solid color-mix(in srgb, var(--accent) 34%, var(--border));
+  border-radius: 8px;
+  background:
+    linear-gradient(135deg, color-mix(in srgb, var(--accent-soft) 68%, transparent), transparent 62%),
+    color-mix(in srgb, var(--surface) 92%, transparent);
+  box-shadow: 0 16px 34px -28px var(--accent);
+  backdrop-filter: blur(10px);
+  transform: translateY(-50%);
+}
+
+.freshPetsNotice .btn {
+  height: 30px;
+  padding: 0 10px;
+  font-size: 11px;
+}
+
+.freshPetsEyebrow,
+.freshPetsCopy {
+  margin: 0;
+}
+
+.freshPetsEyebrow {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  color: var(--accent-deep);
+  font-family: var(--font-mono);
+  font-size: 10px;
+  font-weight: 600;
+  letter-spacing: 0.03em;
+  text-transform: uppercase;
+}
+
+.freshPetsDot {
+  position: relative;
+  width: 7px;
+  height: 7px;
+  border-radius: 999px;
+  background: var(--accent);
+  box-shadow: 0 0 0 4px var(--accent-glow);
+}
+
+.freshPetsDot::after {
+  content: "";
+  position: absolute;
+  inset: -6px;
+  border: 1px solid var(--accent);
+  border-radius: inherit;
+  opacity: 0.22;
+  animation: fresh-pulse 1400ms var(--ease-out) infinite;
+}
+
+.freshPetsCopy {
+  margin-top: 3px;
+  color: var(--ink);
+  font-size: 12px;
+  line-height: 1.2;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .freshPetsDot::after {
+    animation: none;
+  }
+}
+
+@keyframes fresh-pulse {
+  from {
+    opacity: 0.34;
+    transform: scale(0.72);
+  }
+
+  to {
+    opacity: 0;
+    transform: scale(1.4);
+  }
+}
+
 .searchShell {
   position: relative;
   display: block;

--- a/src/gallery/useGalleryBrowser.ts
+++ b/src/gallery/useGalleryBrowser.ts
@@ -1,4 +1,4 @@
-import { useMemo, useState, type Dispatch, type FormEvent, type SetStateAction } from "react";
+import { useEffect, useMemo, useRef, useState, type Dispatch, type FormEvent, type SetStateAction } from "react";
 import {
   defaultGalleryUrlState,
   galleryPageSize,
@@ -48,6 +48,8 @@ export function useGalleryBrowser({
   const [activeKind, setActiveKind] = useState<PetKind>(initialGalleryState.kind);
   const [contentMode, setContentMode] = useState<ContentMode>(initialGalleryState.content);
   const [loading, setLoading] = useState(true);
+  const [freshPetCount, setFreshPetCount] = useState(0);
+  const freshBaselineRef = useRef<{ key: string; total: number } | null>(null);
 
   function applyGalleryState(nextState: GalleryUrlState) {
     setQuery(nextState.query);
@@ -110,6 +112,8 @@ export function useGalleryBrowser({
     const body = await readJson<GalleryResponse>(await apiFetch(`/api/pets${suffix}`, {}, authSession));
     const pageSize = galleryPageSize(view, sort);
     const nextPets = body.pets.map(normalizePet);
+    freshBaselineRef.current = { key: freshGalleryKey(search, tags, content, kind), total: body.total };
+    setFreshPetCount(0);
     setPets(nextPets);
     setGalleryMeta({
       page: body.page,
@@ -149,6 +153,8 @@ export function useGalleryBrowser({
     );
     const randomPets = firstBody.pets.map(normalizePet);
 
+    freshBaselineRef.current = { key: freshGalleryKey(search, tags, content, kind), total: firstBody.total };
+    setFreshPetCount(0);
     setPets(randomPets);
     setGalleryMeta({
       page: 1,
@@ -265,6 +271,45 @@ export function useGalleryBrowser({
     }
   }
 
+  async function showFreshPets() {
+    const nextState = { query, tags: activeTags, sort: "new" as const, page: 1, view: activeView, kind: activeKind, content: contentMode };
+    pushGalleryState(nextState);
+    setLoading(true);
+    try {
+      await loadGallery(nextState.query, nextState.tags, nextState.sort, nextState.page, session, nextState.content, nextState.view, nextState.kind);
+      scrollPageTop();
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  useEffect(() => {
+    if (route.name !== "gallery") return;
+    const key = freshGalleryKey(query, activeTags, contentMode, activeKind);
+    const baseline = freshBaselineRef.current;
+    if (!baseline || baseline.key !== key) return;
+    const baselineTotal = baseline.total;
+    let cancelled = false;
+
+    async function checkFreshPets() {
+      const params = freshGalleryParams(query, activeTags, contentMode, activeKind);
+      const body = await readJson<GalleryResponse>(
+        await apiFetch(`/api/pets?${params}`, {}, session)
+      );
+      if (cancelled) return;
+      setFreshPetCount(Math.max(0, body.total - baselineTotal));
+    }
+
+    const intervalId = window.setInterval(() => {
+      void checkFreshPets().catch(() => {});
+    }, 20000);
+    void checkFreshPets().catch(() => {});
+    return () => {
+      cancelled = true;
+      window.clearInterval(intervalId);
+    };
+  }, [route, query, activeTags, contentMode, activeKind, apiFetch, session, galleryMeta.total]);
+
   async function selectVisibleTag(tag: TagName, sourceTags: string[]) {
     const nextContent = tag === "nsfw" || sourceTags.includes("nsfw") ? "all" : contentMode;
     const nextState = { query: "", tags: [tag], sort: activeSort, page: 1, view: activeView, kind: activeKind, content: nextContent };
@@ -324,7 +369,35 @@ export function useGalleryBrowser({
     selectKind,
     selectPage,
     randomizeGallery,
+    freshPetCount,
+    showFreshPets,
     selectVisibleTag,
     removePetFromGallery
   };
+}
+
+function freshGalleryKey(search: string, tags: string[], content: ContentMode, kind: PetKind) {
+  return JSON.stringify({
+    search,
+    tags: galleryRequestTags(tags),
+    content,
+    kind
+  });
+}
+
+function freshGalleryParams(search: string, tags: string[], content: ContentMode, kind: PetKind) {
+  const params = new URLSearchParams();
+  params.set("page", "1");
+  params.set("pageSize", "1");
+  if (search) {
+    params.set("q", search);
+  }
+  galleryRequestTags(tags).forEach((tag) => params.append("tag", tag));
+  if (kind !== "all") {
+    params.set("kind", kind);
+  }
+  if (content === "all") {
+    params.set("content", "all");
+  }
+  return params.toString();
 }

--- a/src/pets/PetCard.tsx
+++ b/src/pets/PetCard.tsx
@@ -122,6 +122,7 @@ export function PetCard({
   nsfwBusyId,
   contentMode,
   hasCollections,
+  collectionBadge,
   onLike,
   onShare,
   onPlayground,
@@ -147,6 +148,7 @@ export function PetCard({
   nsfwBusyId: string;
   contentMode: ContentMode;
   hasCollections: boolean;
+  collectionBadge?: { slug: string; displayName: string };
   onLike: (pet: Pet) => void;
   onShare: (pet: Pet) => void;
   onPlayground?: (pet: Pet) => void;
@@ -213,6 +215,18 @@ export function PetCard({
             </button>
           )}
         </div>
+      )}
+      {collectionBadge && (
+        <a
+          className="petCardCollectionPill"
+          href={`#/collections/${collectionBadge.slug}`}
+          onClick={stopCardPropagation}
+          onMouseOver={stopCardPropagation}
+          onPointerDown={stopCardPropagation}
+        >
+          <Icon name="package" size={12} />
+          <span>{collectionBadge.displayName}</span>
+        </a>
       )}
       <button className="petCardPreview" type="button" onClick={openPetPage}>
         <GalleryPetPreview pet={pet} compact={compact} />


### PR DESCRIPTION
## Summary
- add public collection labels to gallery pet cards
- show a compact right-side CTA when new gallery pets arrive
- style Worker share pages while keeping crawler metadata

## Verification
- npx tsc -b --pretty false
- /usr/bin/git diff --check
- preview deployed and checked in Safari
- production deployed with tmp/wrangler.prod.toml